### PR TITLE
add bastion diagnostics for darwin nic

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,16 +1,17 @@
 # DarwinNicUtil Agent Guide
 
-This repo owns the generic `darwin-nic` USB management NIC tool. It does not own Tinyland switch topology.
+This repo owns the generic `darwin-nic` USB management NIC tool.
 
-## Source Of Truth Boundaries
+## Boundaries
 
-- `DarwinNicUtil` owns macOS/Linux USB NIC detection, configuration, sudo behavior, routing behavior, and diagnostics.
-- `crs310-8g-2s-in` owns CRS309/CRS310 hostnames, RouterOS policy, OOB MAC addresses, switch credentials, and Tinyland-specific bastion runbooks.
+- Owns macOS/Linux USB NIC detection, configuration, sudo behavior, routing behavior, and diagnostics.
+- Does not own Tinyland switch topology. `crs310-8g-2s-in` owns CRS hostnames, RouterOS policy, OOB MAC addresses, switch credentials, and Tinyland-specific bastion runbooks.
 - Do not embed switch secrets, SOPS paths, or Tinyland-specific RouterOS policy in this repo.
+- Use the `github` remote for GitHub PR work. Local `origin` may be a non-bare `yoga` checkout.
 
 ## Bastion Mode
 
-For hardened `tailnet -> bastion host -> USB OOB NIC -> network gear` workflows, this tool should provide:
+For `tailnet -> bastion host -> USB OOB NIC -> network gear` workflows, provide:
 
 - profile-driven USB NIC setup with Wi-Fi preservation;
 - clear dry-run/status output before privileged changes;

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,40 @@
+# DarwinNicUtil Agent Guide
+
+This repo owns the generic `darwin-nic` USB management NIC tool. It does not own Tinyland switch topology.
+
+## Source Of Truth Boundaries
+
+- `DarwinNicUtil` owns macOS/Linux USB NIC detection, configuration, sudo behavior, routing behavior, and diagnostics.
+- `crs310-8g-2s-in` owns CRS309/CRS310 hostnames, RouterOS policy, OOB MAC addresses, switch credentials, and Tinyland-specific bastion runbooks.
+- Do not embed switch secrets, SOPS paths, or Tinyland-specific RouterOS policy in this repo.
+
+## Bastion Mode
+
+For hardened `tailnet -> bastion host -> USB OOB NIC -> network gear` workflows, this tool should provide:
+
+- profile-driven USB NIC setup with Wi-Fi preservation;
+- clear dry-run/status output before privileged changes;
+- normal interactive sudo in non-TUI CLI mode;
+- TUI-safe sudo only after pre-authentication;
+- diagnostics for `scutil --nwi`, active Tailscale system extension state, and recent macOS `reason: NECP` socket drops.
+
+Tinyland CRS309-specific commands belong in `crs310-8g-2s-in`; the generic operator action here is:
+
+```bash
+darwin-nic status
+darwin-nic configure --profile homelab --preserve-wifi
+```
+
+## Validation
+
+Run the full Python test suite after changing runtime behavior or docs that are covered by tests:
+
+```bash
+uv run --extra dev python -m pytest -q
+```
+
+For publishable changes, also check formatting/lint/type surfaces when the local toolchain is available:
+
+```bash
+just check
+```

--- a/README.md
+++ b/README.md
@@ -100,8 +100,8 @@ preserve_wifi = true
 [profiles.homelab]
 device_ip = "192.168.88.1"
 laptop_ip = "192.168.88.100"
-mgmt_network = "192.168.10.0/24"
-device_name = "Bastion Switch"
+mgmt_network = "192.168.88.0/24"
+device_name = "CRS309 Bastion"
 
 [profiles.datacenter]
 device_ip = "10.200.0.1"
@@ -126,10 +126,21 @@ Realtek, ASIX, Belkin, Apple USB Ethernet, StarTech, Cable Matters, TP-Link, and
 - **WiFi Preservation**: Automatically maintains internet connectivity when configuring USB NICs
 - **USB Priority Prevention**: Prevents macOS from routing traffic through USB NIC
 - **Dry-Run Mode**: Preview all changes before applying
+- **Bastion Diagnostics**: `darwin-nic status` now surfaces USB OOB, `scutil --nwi`, Tailscale system-extension, and recent NECP-drop hints
 - Emergency Recovery, os noes!
 ```bash
 ./scripts/emergency-restore.sh
 ```
+
+## Bastion / OOB Notes
+
+For a hardened `tailnet -> bastion host -> USB OOB NIC -> network gear` flow:
+
+- keep your profile `mgmt_network` aligned to the real OOB subnet, not the RFC5737 default
+- use `darwin-nic status` when ordinary sockets fail but raw tools still work
+- if the status output shows the USB interface missing from `scutil --nwi` while the Tailscale Network Extension is active, macOS may be blocking ordinary sockets with NECP even though link and ARP are healthy
+
+For CLI use, non-TUI `darwin-nic configure` now uses the normal interactive sudo path. If you want a non-interactive shell script, pre-authenticate first with `sudo -v` or provide your own wrapper.
 
 ## Helpful stuff
 
@@ -137,6 +148,9 @@ Realtek, ASIX, Belkin, Apple USB Ethernet, StarTech, Cable Matters, TP-Link, and
 # Check if adapter is recognized
 networksetup -listallhardwareports  # macOS
 ip link show                        # Linux
+
+# Inspect bastion/OOB status
+darwin-nic status
 
 # Run with verbose logging
 darwin-nic configure --device-ip <ipv4> --laptop-ip <ipv4> --dry-run

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -205,8 +205,8 @@ preserve_wifi = true
 [profiles.homelab]
 device_ip = "192.168.88.1"
 laptop_ip = "192.168.88.100"
-mgmt_network = "192.168.10.0/24"
-device_name = "Management Switch"
+mgmt_network = "192.168.88.0/24"
+device_name = "CRS309 Bastion"
 description = "Home lab network"
 
 [profiles.datacenter]

--- a/docs/development.md
+++ b/docs/development.md
@@ -5,7 +5,7 @@
 ```bash
 # Clone repository
 git clone https://github.com/Jesssullivan/DarwinNicUtil.git
-cd darwin-mgmt-nic-configurator
+cd DarwinNicUtil
 
 # Create virtual environment (Python 3.14+)
 python3 -m venv venv
@@ -18,7 +18,7 @@ pip install -e ".[dev]"
 ## Project Structure
 
 ```
-darwin-mgmt-nic-configurator/
+DarwinNicUtil/
 ├── darwin-nic              # Main entry point
 ├── darwin-nic-venv         # Venv wrapper
 ├── src/darwin_mgmt_nic/    # Source code

--- a/docs/development.md
+++ b/docs/development.md
@@ -4,7 +4,7 @@
 
 ```bash
 # Clone repository
-git clone https://gitlab.com/tinyland/projects/darwin-mgmt-nic-configurator.git
+git clone https://github.com/Jesssullivan/DarwinNicUtil.git
 cd darwin-mgmt-nic-configurator
 
 # Create virtual environment (Python 3.14+)
@@ -215,7 +215,7 @@ flowchart LR
 6. Run tests: `./scripts/run_tests.sh`
 7. Commit: `git commit -m 'Add amazing feature'`
 8. Push: `git push origin feature/amazing-feature`
-9. Open Merge Request
+9. Open a pull request
 
 ### Commit Messages
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -79,8 +79,8 @@ default_profile = "homelab"
 [profiles.homelab]
 device_ip = "192.168.88.1"
 laptop_ip = "192.168.88.100"
-mgmt_network = "192.168.10.0/24"
-device_name = "Management Switch"
+mgmt_network = "192.168.88.0/24"
+device_name = "CRS309 Bastion"
 ```
 
 ## CLI Configuration
@@ -122,6 +122,10 @@ darwin-nic configure \
 ./darwin-nic dashboard
 ```
 
+If `status` shows the USB interface missing from `scutil --nwi` while the
+Tailscale system extension is active, ordinary sockets may be getting blocked
+by macOS NECP even though the USB link itself is healthy.
+
 ## Troubleshooting
 
 ### USB Interface Not Detected
@@ -134,8 +138,9 @@ networksetup -listallhardwareports
 ### Permission Denied
 
 ```bash
-# Run with sudo
-sudo ./darwin-nic configure --device-ip 192.0.2.1 --laptop-ip 192.0.2.100
+# Pre-authenticate sudo, then rerun configure
+sudo -v
+./darwin-nic configure --device-ip 192.0.2.1 --laptop-ip 192.0.2.100
 ```
 
 ### Emergency Recovery

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -7,7 +7,7 @@ Get up and running in under 5 minutes.
 === "Clone & Run"
 
     ```bash
-    git clone https://gitlab.com/tinyland/projects/darwin-mgmt-nic-configurator.git
+    git clone https://github.com/Jesssullivan/DarwinNicUtil.git
     cd darwin-mgmt-nic-configurator
 
     python3 -m venv venv

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -8,7 +8,7 @@ Get up and running in under 5 minutes.
 
     ```bash
     git clone https://github.com/Jesssullivan/DarwinNicUtil.git
-    cd darwin-mgmt-nic-configurator
+    cd DarwinNicUtil
 
     python3 -m venv venv
     source venv/bin/activate

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
 site_name: Darwin Management NIC Configurator
 site_description: USB network interface configurator with WiFi preservation
-site_url: https://tinyland.gitlab.io/projects/darwin-mgmt-nic-configurator
-repo_url: https://gitlab.com/tinyland/projects/darwin-mgmt-nic-configurator
+site_url: https://jesssullivan.github.io/DarwinNicUtil
+repo_url: https://github.com/Jesssullivan/DarwinNicUtil
 repo_name: tinyland/darwin-mgmt-nic-configurator
 
 theme:
@@ -57,5 +57,5 @@ nav:
 
 extra:
   social:
-    - icon: fontawesome/brands/gitlab
-      link: https://gitlab.com/tinyland/projects/darwin-mgmt-nic-configurator
+    - icon: fontawesome/brands/github
+      link: https://github.com/Jesssullivan/DarwinNicUtil

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,7 +2,7 @@ site_name: Darwin Management NIC Configurator
 site_description: USB network interface configurator with WiFi preservation
 site_url: https://jesssullivan.github.io/DarwinNicUtil
 repo_url: https://github.com/Jesssullivan/DarwinNicUtil
-repo_name: tinyland/darwin-mgmt-nic-configurator
+repo_name: Jesssullivan/DarwinNicUtil
 
 theme:
   name: material

--- a/nix/net-utils.nix
+++ b/nix/net-utils.nix
@@ -9,7 +9,7 @@
   mtr,
   iperf3,
   socat,
-  netcat-openbsd,
+  netcat-openbsd ? null,  # permanently broken on Darwin (Debian Linux-only port)
   # Extended tools
   bandwhich,
   trippy,
@@ -33,8 +33,8 @@ let
     mtr
     iperf3
     socat
-    netcat-openbsd
-  ];
+  ] ++ lib.optional (netcat-openbsd != null && !(netcat-openbsd.meta.broken or false))
+    netcat-openbsd;
 
   extendedTools = lib.optionals enableExtended [
     bandwhich

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,9 +52,9 @@ dev = [
 darwin-nic = "darwin_mgmt_nic.app:main"
 
 [project.urls]
-Homepage = "https://gitlab.com/tinyland/projects/darwin-mgmt-nic-configurator"
-Repository = "https://gitlab.com/tinyland/projects/darwin-mgmt-nic-configurator.git"
-Issues = "https://gitlab.com/tinyland/projects/darwin-mgmt-nic-configurator/-/issues"
+Homepage = "https://github.com/Jesssullivan/DarwinNicUtil"
+Repository = "https://github.com/Jesssullivan/DarwinNicUtil.git"
+Issues = "https://github.com/Jesssullivan/DarwinNicUtil/issues"
 
 [build-system]
 requires = ["hatchling"]

--- a/src/darwin_mgmt_nic/app.py
+++ b/src/darwin_mgmt_nic/app.py
@@ -108,6 +108,62 @@ def cmd_status(args: argparse.Namespace) -> None:
     dashboard.display_status()
     console.print("\n")
     dashboard.show_connectivity_metrics()
+    print_bastion_diagnostics(console)
+
+
+def print_bastion_diagnostics(console, detector=None) -> None:
+    """Print high-signal bastion/OOB diagnostics when USB management state exists."""
+    from rich.panel import Panel
+    from rich.table import Table
+
+    from .factory import USBNICDetectorFactory
+
+    detector = detector or USBNICDetectorFactory.create()
+    if not hasattr(detector, "get_bastion_diagnostics"):
+        return
+
+    diagnostics = detector.get_bastion_diagnostics()
+    if not diagnostics.usb_interfaces_with_ip:
+        return
+
+    table = Table(box=None, show_header=False, pad_edge=False)
+    table.add_column(style="cyan")
+    table.add_column(style="white")
+    table.add_row("USB OOB", ", ".join(diagnostics.usb_interfaces_with_ip))
+    table.add_row(
+        "NWI",
+        ", ".join(diagnostics.nwi_interfaces) if diagnostics.nwi_interfaces else "none",
+    )
+    table.add_row(
+        "Missing from NWI",
+        ", ".join(diagnostics.missing_from_nwi) if diagnostics.missing_from_nwi else "none",
+    )
+    table.add_row(
+        "Tailscale sysext",
+        "active" if diagnostics.tailscale_extension_active else "inactive",
+    )
+    table.add_row(
+        "Recent NECP drops",
+        "yes" if diagnostics.recent_necp_drop else "no",
+    )
+
+    console.print(
+        Panel(
+            table,
+            title="Bastion OOB Diagnostics",
+            border_style="magenta",
+        )
+    )
+
+    if diagnostics.missing_from_nwi and diagnostics.tailscale_extension_active:
+        console.print(
+            "[yellow]Warning:[/yellow] USB OOB interface is outside `scutil --nwi` "
+            "while the Tailscale Network Extension is active. Ordinary sockets may be blocked."
+        )
+    if diagnostics.recent_necp_drop:
+        console.print(
+            "[yellow]Warning:[/yellow] Recent macOS logs show `reason: NECP` drops for outbound sockets."
+        )
 
 
 def cmd_dashboard(args: argparse.Namespace) -> None:

--- a/src/darwin_mgmt_nic/macos.py
+++ b/src/darwin_mgmt_nic/macos.py
@@ -7,6 +7,7 @@ import re
 import logging
 import os
 import sys
+from dataclasses import dataclass
 from typing import Optional, Sequence
 from rich.console import Console
 from rich.prompt import Prompt
@@ -16,6 +17,17 @@ from .config import NetworkInterface, InterfaceName, IPAddress
 
 logger = logging.getLogger(__name__)
 console = Console()
+
+
+@dataclass(frozen=True, slots=True)
+class BastionDiagnostics:
+    """High-signal bastion-mode facts for USB OOB troubleshooting."""
+
+    usb_interfaces_with_ip: list[str]
+    nwi_interfaces: list[str]
+    missing_from_nwi: list[str]
+    tailscale_extension_active: bool
+    recent_necp_drop: bool
 
 
 def run_sudo_command(cmd: Sequence[str], timeout: int = 30, check: bool = True) -> subprocess.CompletedProcess:
@@ -153,6 +165,27 @@ class MacOSUSBNICDetector(USBNICDetector):
             tui_mode: If True, use TUI-safe sudo commands (assumes pre-auth)
         """
         self.tui_mode = tui_mode
+
+    def _run_privileged_command(
+        self,
+        cmd: Sequence[str],
+        timeout: int = 30,
+        check: bool = True,
+    ) -> subprocess.CompletedProcess:
+        """
+        Run a privileged command using the right sudo contract for the current mode.
+
+        Non-TUI CLI mode should preserve interactive sudo behavior.
+        TUI mode assumes pre-authenticated sudo and must avoid terminal corruption.
+        """
+        if self.tui_mode:
+            return run_sudo_command_tui_safe(
+                cmd,
+                timeout=timeout,
+                check=check,
+                tui_active=True,
+            )
+        return run_sudo_command(cmd, timeout=timeout, check=check)
 
     def detect_interfaces(self) -> Sequence[NetworkInterface]:
         """
@@ -377,11 +410,10 @@ class MacOSUSBNICDetector(USBNICDetector):
             if iface.current_ip == target_ip:
                 logger.info(f"[*] Removing conflicting IP {target_ip} from {iface.name}")
                 try:
-                    run_sudo_command_tui_safe(
+                    self._run_privileged_command(
                         ["ifconfig", iface.name, target_ip, "-alias"],
                         check=False,
                         timeout=10,
-                        tui_active=self.tui_mode
                     )
                 except Exception as e:
                     logger.warning(f"Failed to remove IP from {iface.name}: {e}")
@@ -404,19 +436,17 @@ class MacOSUSBNICDetector(USBNICDetector):
             existing_ip = self._get_interface_ip(interface)
             if existing_ip:
                 logger.info(f"Removing existing IP {existing_ip} from {interface}")
-                run_sudo_command_tui_safe(
+                self._run_privileged_command(
                     ["ifconfig", interface, existing_ip, "-alias"],
                     check=False,
                     timeout=30,
-                    tui_active=self.tui_mode
                 )
 
             # Configure new IP
             logger.info(f"Configuring {interface}: {ip}/{netmask}")
-            run_sudo_command_tui_safe(
+            self._run_privileged_command(
                 ["ifconfig", interface, ip, "netmask", netmask, "up"],
                 timeout=30,
-                tui_active=self.tui_mode
             )
 
             # Verify configuration
@@ -450,10 +480,9 @@ class MacOSUSBNICDetector(USBNICDetector):
 
             # Add route
             logger.info(f"Adding static route: {network} via {gateway}")
-            run_sudo_command_tui_safe(
+            self._run_privileged_command(
                 ["route", "add", "-net", network, gateway],
                 timeout=30,
-                tui_active=self.tui_mode
             )
 
             logger.info(f"[OK] Static route added: {network} via {gateway}")
@@ -489,3 +518,88 @@ class MacOSUSBNICDetector(USBNICDetector):
         except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
             logger.error(f"[FAIL] Connectivity test failed: {e}")
             return False
+
+    def get_bastion_diagnostics(self) -> BastionDiagnostics:
+        """
+        Collect high-signal macOS bastion facts for USB OOB debugging.
+
+        This is intentionally best-effort and should never raise on operator hosts.
+        """
+        usb_interfaces_with_ip = [
+            iface.name
+            for iface in self.detect_interfaces()
+            if iface.is_usb and iface.current_ip
+        ]
+        nwi_interfaces = self._get_nwi_interfaces()
+        missing_from_nwi = [
+            interface for interface in usb_interfaces_with_ip if interface not in nwi_interfaces
+        ]
+
+        return BastionDiagnostics(
+            usb_interfaces_with_ip=usb_interfaces_with_ip,
+            nwi_interfaces=nwi_interfaces,
+            missing_from_nwi=missing_from_nwi,
+            tailscale_extension_active=self._tailscale_extension_active(),
+            recent_necp_drop=self._recent_necp_drop_detected(),
+        )
+
+    def _get_nwi_interfaces(self) -> list[str]:
+        """Parse interface membership from `scutil --nwi`."""
+        try:
+            result = subprocess.run(
+                ["scutil", "--nwi"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+                check=False,
+            )
+        except Exception as e:
+            logger.debug(f"Failed to query scutil --nwi: {e}")
+            return []
+
+        for line in result.stdout.splitlines():
+            if line.startswith("Network interfaces:"):
+                _, interfaces = line.split(":", 1)
+                return [item for item in interfaces.strip().split() if item]
+        return []
+
+    def _tailscale_extension_active(self) -> bool:
+        """Check whether the Tailscale system extension is active."""
+        try:
+            result = subprocess.run(
+                ["systemextensionsctl", "list"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+                check=False,
+            )
+        except Exception as e:
+            logger.debug(f"Failed to query system extensions: {e}")
+            return False
+
+        return "io.tailscale.ipn.macsys.network-extension" in result.stdout
+
+    def _recent_necp_drop_detected(self) -> bool:
+        """Check recent macOS logs for NECP socket drops on the bastion host."""
+        try:
+            result = subprocess.run(
+                [
+                    "log",
+                    "show",
+                    "--style",
+                    "compact",
+                    "--last",
+                    "10m",
+                    "--predicate",
+                    'eventMessage CONTAINS[c] "tcp drop outgoing" OR eventMessage CONTAINS[c] "reason: NECP"',
+                ],
+                capture_output=True,
+                text=True,
+                timeout=15,
+                check=False,
+            )
+        except Exception as e:
+            logger.debug(f"Failed to query recent logs for NECP drops: {e}")
+            return False
+
+        return "reason: NECP" in result.stdout

--- a/src/darwin_mgmt_nic/settings.py
+++ b/src/darwin_mgmt_nic/settings.py
@@ -310,15 +310,15 @@ dry_run = false
 [profiles.homelab]
 device_ip = "192.168.88.1"
 laptop_ip = "192.168.88.100"
-mgmt_network = "192.168.10.0/24"
-device_name = "Bastion Switch"
+mgmt_network = "192.168.88.0/24"
+device_name = "CRS309 Bastion"
 description = "Home lab management network"
 # device_type = "mikrotik"  # Optional: for future device-specific features
 
 [profiles.homelab-secondary]
 device_ip = "192.168.88.2"
 laptop_ip = "192.168.88.100"
-mgmt_network = "192.168.10.0/24"
+mgmt_network = "192.168.88.0/24"
 device_name = "Secondary Switch"
 description = "Secondary management target"
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -2,10 +2,13 @@
 Tests for app-level operator diagnostics.
 """
 
+import argparse
+import sys
 from unittest.mock import MagicMock
 
-from darwin_mgmt_nic.app import print_bastion_diagnostics
+from darwin_mgmt_nic.app import cmd_configure, print_bastion_diagnostics
 from darwin_mgmt_nic.macos import BastionDiagnostics
+from darwin_mgmt_nic.settings import NetworkProfile, Settings
 
 
 class TestPrintBastionDiagnostics:
@@ -47,3 +50,73 @@ class TestPrintBastionDiagnostics:
         print_bastion_diagnostics(console, detector)
 
         console.print.assert_not_called()
+
+
+class TestCmdConfigure:
+    """Test app-level configure dispatch into the CLI implementation."""
+
+    def test_profile_configure_builds_cli_argv_with_preserve_wifi(self, monkeypatch):
+        """Profile mode should pass resolved OOB values to the CLI surface."""
+        called = {}
+
+        def fake_cli_main():
+            called["argv"] = list(sys.argv)
+
+        monkeypatch.setattr("darwin_mgmt_nic.cli.main", fake_cli_main)
+
+        settings = Settings(
+            profiles={
+                "homelab": NetworkProfile(
+                    device_ip="192.168.88.1",
+                    laptop_ip="192.168.88.100",
+                    mgmt_network="192.168.88.0/24",
+                    device_name="CRS309 Bastion",
+                )
+            }
+        )
+        args = argparse.Namespace(
+            profile="homelab",
+            device_ip="__PROFILE__",
+            laptop_ip="__PROFILE__",
+            netmask="255.255.255.0",
+            mgmt_network="198.51.100.0/24",
+            device_name="Network Device",
+            dry_run=True,
+            preserve_wifi=True,
+            show_dashboard=False,
+        )
+
+        assert cmd_configure(args, settings) is None
+
+        assert called["argv"] == [
+            "darwin-mgmt-nic",
+            "--device-ip",
+            "192.168.88.1",
+            "--laptop-ip",
+            "192.168.88.100",
+            "--netmask",
+            "255.255.255.0",
+            "--mgmt-network",
+            "192.168.88.0/24",
+            "--device-name",
+            "CRS309 Bastion",
+            "--dry-run",
+            "--preserve-wifi",
+        ]
+
+    def test_configure_requires_ips_without_profile(self, capsys):
+        """CLI mode should fail closed instead of invoking configure with placeholders."""
+        args = argparse.Namespace(
+            profile=None,
+            device_ip="__PROFILE__",
+            laptop_ip="__PROFILE__",
+            netmask="255.255.255.0",
+            mgmt_network="198.51.100.0/24",
+            device_name="Network Device",
+            dry_run=False,
+            preserve_wifi=False,
+            show_dashboard=False,
+        )
+
+        assert cmd_configure(args, Settings()) == 1
+        assert "--device-ip and --laptop-ip are required" in capsys.readouterr().out

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,49 @@
+"""
+Tests for app-level operator diagnostics.
+"""
+
+from unittest.mock import MagicMock
+
+from darwin_mgmt_nic.app import print_bastion_diagnostics
+from darwin_mgmt_nic.macos import BastionDiagnostics
+
+
+class TestPrintBastionDiagnostics:
+    """Test status-surface bastion diagnostics."""
+
+    def test_prints_high_signal_bastion_warnings(self):
+        """Operator status should surface the same NECP/Tailscale hints we saw on pzm."""
+        console = MagicMock()
+        detector = MagicMock()
+        detector.get_bastion_diagnostics.return_value = BastionDiagnostics(
+            usb_interfaces_with_ip=["en9"],
+            nwi_interfaces=["en1", "en0"],
+            missing_from_nwi=["en9"],
+            tailscale_extension_active=True,
+            recent_necp_drop=True,
+        )
+
+        print_bastion_diagnostics(console, detector)
+
+        panel = console.print.call_args_list[0].args[0]
+        assert panel.title == "Bastion OOB Diagnostics"
+
+        rendered = "\n".join(str(call.args[0]) for call in console.print.call_args_list[1:])
+        assert "Tailscale" in rendered
+        assert "NECP" in rendered
+
+    def test_skips_output_without_usb_bastion_state(self):
+        """No USB bastion state means no extra status noise."""
+        console = MagicMock()
+        detector = MagicMock()
+        detector.get_bastion_diagnostics.return_value = BastionDiagnostics(
+            usb_interfaces_with_ip=[],
+            nwi_interfaces=["en1", "en0"],
+            missing_from_nwi=[],
+            tailscale_extension_active=False,
+            recent_necp_drop=False,
+        )
+
+        print_bastion_diagnostics(console, detector)
+
+        console.print.assert_not_called()

--- a/tests/test_configurator.py
+++ b/tests/test_configurator.py
@@ -3,7 +3,7 @@ Tests for main configurator
 """
 
 import pytest
-from unittest.mock import MagicMock, patch
+from unittest.mock import ANY, MagicMock, patch
 from darwin_mgmt_nic.configurator import USBNICConfigurator
 
 
@@ -103,40 +103,45 @@ class TestUSBNICConfigurator:
         configurator = USBNICConfigurator(sample_network_config, dry_run=False)
         assert not configurator.confirm_configuration(protected_interface)
 
-    @patch('builtins.input', return_value='yes')
+    @patch('darwin_mgmt_nic.configurator.Confirm.ask', return_value=True)
     def test_confirm_configuration_user_accepts(
         self,
-        mock_input,
+        mock_confirm,
         sample_network_config,
         usb_interface_active
     ):
         """Test user accepts configuration"""
         configurator = USBNICConfigurator(sample_network_config, dry_run=False)
         assert configurator.confirm_configuration(usb_interface_active)
+        mock_confirm.assert_called_once_with(
+            "Proceed with configuration?",
+            default=True,
+            console=ANY,
+        )
 
-    @patch('builtins.input', return_value='no')
+    @patch('darwin_mgmt_nic.configurator.Confirm.ask', return_value=False)
     def test_confirm_configuration_user_rejects(
         self,
-        mock_input,
+        mock_confirm,
         sample_network_config,
         usb_interface_active
     ):
         """Test user rejects configuration"""
         configurator = USBNICConfigurator(sample_network_config, dry_run=False)
         assert not configurator.confirm_configuration(usb_interface_active)
+        mock_confirm.assert_called_once()
 
-    @patch('builtins.input', side_effect=['maybe', 'invalid', 'yes'])
-    def test_confirm_configuration_invalid_input(
+    @patch('darwin_mgmt_nic.configurator.Confirm.ask', return_value=True)
+    def test_confirm_configuration_uses_rich_confirm(
         self,
-        mock_input,
+        mock_confirm,
         sample_network_config,
         usb_interface_active
     ):
-        """Test handling invalid user input"""
+        """Test configurator delegates interactive confirmation to Rich."""
         configurator = USBNICConfigurator(sample_network_config, dry_run=False)
         assert configurator.confirm_configuration(usb_interface_active)
-        # Should have been called 3 times
-        assert mock_input.call_count == 3
+        mock_confirm.assert_called_once()
 
     def test_configure_dry_run(self, sample_network_config, usb_interface_active):
         """Test dry-run configuration (no actual changes)"""
@@ -156,10 +161,10 @@ class TestUSBNICConfigurator:
         mock_detector.configure_interface.assert_not_called()
         mock_detector.add_static_route.assert_not_called()
 
-    @patch('builtins.input', return_value='yes')
+    @patch('darwin_mgmt_nic.configurator.Confirm.ask', return_value=True)
     def test_configure_success(
         self,
-        mock_input,
+        mock_confirm,
         sample_network_config,
         usb_interface_active
     ):
@@ -167,7 +172,6 @@ class TestUSBNICConfigurator:
         mock_detector = MagicMock()
         mock_detector.detect_interfaces.return_value = [usb_interface_active]
         mock_detector.configure_interface.return_value = True
-        mock_detector.add_static_route.return_value = True
         mock_detector.test_connectivity.return_value = True
 
         configurator = USBNICConfigurator(
@@ -175,18 +179,24 @@ class TestUSBNICConfigurator:
             dry_run=False,
             detector=mock_detector
         )
+        configurator.route_manager = MagicMock()
 
         result = configurator.configure()
         assert result is True
 
         # Verify methods were called
         mock_detector.configure_interface.assert_called_once()
-        mock_detector.add_static_route.assert_called_once()
+        configurator.route_manager.add_management_route.assert_called_once_with(
+            sample_network_config.mgmt_network,
+            usb_interface_active.name,
+            sample_network_config.device_ip,
+        )
+        mock_confirm.assert_called_once()
 
-    @patch('builtins.input', return_value='yes')
+    @patch('darwin_mgmt_nic.configurator.Confirm.ask', return_value=True)
     def test_configure_failure(
         self,
-        mock_input,
+        mock_confirm,
         sample_network_config,
         usb_interface_active
     ):
@@ -200,6 +210,9 @@ class TestUSBNICConfigurator:
             dry_run=False,
             detector=mock_detector
         )
+        configurator.route_manager = MagicMock()
 
         result = configurator.configure()
         assert result is False
+        configurator.route_manager.add_management_route.assert_not_called()
+        mock_confirm.assert_called_once()

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -26,3 +26,13 @@ def test_operator_docs_do_not_point_at_retired_gitlab_repository():
     ]
 
     assert stale == []
+
+
+def test_agents_file_keeps_crs_policy_out_of_darwin_tool():
+    agents = (REPO_ROOT / "AGENTS.md").read_text()
+
+    assert "generic `darwin-nic` USB management NIC tool" in agents
+    assert "Do not embed switch secrets" in agents
+    assert "Use the `github` remote" in agents
+    assert "crs309-main" not in agents
+    assert "vault_mikrotik_password" not in agents

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -28,6 +28,19 @@ def test_operator_docs_do_not_point_at_retired_gitlab_repository():
     assert stale == []
 
 
+def test_clone_instructions_match_github_repo_directory():
+    development = (REPO_ROOT / "docs" / "development.md").read_text()
+    quickstart = (REPO_ROOT / "docs" / "quickstart.md").read_text()
+    mkdocs = (REPO_ROOT / "mkdocs.yml").read_text()
+
+    assert "git clone https://github.com/Jesssullivan/DarwinNicUtil.git\ncd DarwinNicUtil" in development
+    assert "git clone https://github.com/Jesssullivan/DarwinNicUtil.git\n    cd DarwinNicUtil" in quickstart
+    assert "repo_name: Jesssullivan/DarwinNicUtil" in mkdocs
+    assert "cd darwin-mgmt-nic-configurator" not in development
+    assert "cd darwin-mgmt-nic-configurator" not in quickstart
+    assert "repo_name: tinyland/darwin-mgmt-nic-configurator" not in mkdocs
+
+
 def test_agents_file_keeps_crs_policy_out_of_darwin_tool():
     agents = (REPO_ROOT / "AGENTS.md").read_text()
 

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).parent.parent
+
+
+def test_project_metadata_points_at_github_repository():
+    pyproject = (REPO_ROOT / "pyproject.toml").read_text()
+
+    assert "https://github.com/Jesssullivan/DarwinNicUtil" in pyproject
+    assert "gitlab.com/tinyland/projects/darwin-mgmt-nic-configurator" not in pyproject
+
+
+def test_operator_docs_do_not_point_at_retired_gitlab_repository():
+    docs = [
+        REPO_ROOT / "README.md",
+        REPO_ROOT / "docs" / "development.md",
+        REPO_ROOT / "docs" / "quickstart.md",
+        REPO_ROOT / "mkdocs.yml",
+    ]
+
+    stale = [
+        str(path.relative_to(REPO_ROOT))
+        for path in docs
+        if "gitlab.com/tinyland/projects/darwin-mgmt-nic-configurator" in path.read_text()
+    ]
+
+    assert stale == []

--- a/tests/test_macos.py
+++ b/tests/test_macos.py
@@ -4,6 +4,7 @@ Tests for macOS-specific implementation
 
 import pytest
 from unittest.mock import MagicMock, patch
+from darwin_mgmt_nic.config import NetworkInterface
 from darwin_mgmt_nic.macos import MacOSUSBNICDetector
 
 
@@ -123,6 +124,120 @@ class TestMacOSUSBNICDetector:
 
         with pytest.raises(ValueError, match="protected"):
             detector.configure_interface("en0", "192.0.2.100", "255.255.255.0")
+
+    @patch("darwin_mgmt_nic.macos.run_sudo_command_tui_safe")
+    @patch("darwin_mgmt_nic.macos.run_sudo_command")
+    @patch.object(MacOSUSBNICDetector, "cleanup_conflicting_ips")
+    @patch.object(MacOSUSBNICDetector, "validate_interface_for_config")
+    @patch.object(MacOSUSBNICDetector, "_get_interface_ip")
+    def test_configure_interface_non_tui_uses_interactive_runner(
+        self,
+        mock_get_ip,
+        mock_validate,
+        mock_cleanup,
+        mock_run_sudo,
+        mock_run_sudo_tui,
+    ):
+        """Non-TUI CLI mode should use the interactive sudo runner."""
+        mock_get_ip.side_effect = [None, "192.0.2.100"]
+
+        detector = MacOSUSBNICDetector(tui_mode=False)
+
+        assert detector.configure_interface("en7", "192.0.2.100", "255.255.255.0")
+        mock_run_sudo.assert_called_once_with(
+            ["ifconfig", "en7", "192.0.2.100", "netmask", "255.255.255.0", "up"],
+            timeout=30,
+            check=True,
+        )
+        mock_run_sudo_tui.assert_not_called()
+
+    @patch("darwin_mgmt_nic.macos.run_sudo_command_tui_safe")
+    @patch("darwin_mgmt_nic.macos.run_sudo_command")
+    @patch.object(MacOSUSBNICDetector, "cleanup_conflicting_ips")
+    @patch.object(MacOSUSBNICDetector, "validate_interface_for_config")
+    @patch.object(MacOSUSBNICDetector, "_get_interface_ip")
+    def test_configure_interface_tui_uses_tui_runner(
+        self,
+        mock_get_ip,
+        mock_validate,
+        mock_cleanup,
+        mock_run_sudo,
+        mock_run_sudo_tui,
+    ):
+        """TUI mode should keep using the non-interactive TUI-safe runner."""
+        mock_get_ip.side_effect = [None, "192.0.2.100"]
+
+        detector = MacOSUSBNICDetector(tui_mode=True)
+
+        assert detector.configure_interface("en7", "192.0.2.100", "255.255.255.0")
+        mock_run_sudo_tui.assert_called_once_with(
+            ["ifconfig", "en7", "192.0.2.100", "netmask", "255.255.255.0", "up"],
+            timeout=30,
+            check=True,
+            tui_active=True,
+        )
+        mock_run_sudo.assert_not_called()
+
+    @patch("subprocess.run")
+    def test_get_bastion_diagnostics_detects_nwi_necp_and_tailscale(self, mock_run):
+        """Bastion diagnostics should surface the same host-side symptoms we saw on pzm."""
+        def run_side_effect(cmd, *args, **kwargs):
+            if cmd[:2] == ["scutil", "--nwi"]:
+                return MagicMock(
+                    returncode=0,
+                    stdout=(
+                        "Network information\n\n"
+                        "IPv4 network interface information\n"
+                        "     en1 : flags      : 0x5 (IPv4,DNS)\n"
+                        "           address    : 192.168.30.112\n\n"
+                        "Network interfaces: en1 en0\n"
+                    ),
+                )
+            if cmd[:2] == ["systemextensionsctl", "list"]:
+                return MagicMock(
+                    returncode=0,
+                    stdout=(
+                        "1 extension(s)\n"
+                        "--- com.apple.system_extension.network_extension\n"
+                        "* * W5364U7YZB io.tailscale.ipn.macsys.network-extension "
+                        "(1.87.103/101.87.103) Tailscale Network Extension [activated enabled]\n"
+                    ),
+                )
+            if cmd[:2] == ["log", "show"]:
+                return MagicMock(
+                    returncode=0,
+                    stdout=(
+                        "2026-04-24 11:58:38.135 Df kernel[0:140ce66] "
+                        "tcp drop outgoing interface: en9 reason: NECP\n"
+                    ),
+                )
+            raise AssertionError(f"Unexpected command: {cmd}")
+
+        mock_run.side_effect = run_side_effect
+
+        detector = MacOSUSBNICDetector()
+        detector.detect_interfaces = MagicMock(
+            return_value=[
+                NetworkInterface(
+                    name="en9",
+                    hardware_port="USB 10/100/1000 LAN",
+                    is_usb=True,
+                    is_active=True,
+                    is_protected=False,
+                    current_ip="192.168.88.100",
+                    mac_address="a0:ce:c8:d9:c7:5c",
+                    vendor="Realtek",
+                )
+            ]
+        )
+
+        diagnostics = detector.get_bastion_diagnostics()
+
+        assert diagnostics.usb_interfaces_with_ip == ["en9"]
+        assert diagnostics.nwi_interfaces == ["en1", "en0"]
+        assert diagnostics.missing_from_nwi == ["en9"]
+        assert diagnostics.tailscale_extension_active is True
+        assert diagnostics.recent_necp_drop is True
 
     @patch('subprocess.run')
     def test_add_static_route_already_exists(self, mock_run):


### PR DESCRIPTION
## Summary

Adds bastion-mode diagnostics and fixes the non-TUI sudo path used by `darwin-nic configure`, matching the CRS309/petting-zoo-mini OOB findings.

Also adds repo-local `AGENTS.md` guidance, updates repository metadata/docs from the retired GitLab URL to GitHub, fixes GitHub clone-directory drift, and adds docs/usage regression tests so stale URL/operator-flow drift does not return.

## Validation

- `UV_CACHE_DIR=/tmp/uv-cache UV_PROJECT_ENVIRONMENT=/tmp/darwin-nic-venv uv run --extra dev python -m pytest -q` -> `76 passed`
- `UV_CACHE_DIR=/tmp/uv-cache UV_PROJECT_ENVIRONMENT=/tmp/darwin-nic-venv uv run --extra dev python -m pytest tests/test_app.py tests/test_docs.py tests/test_macos.py -q` -> `27 passed`
- `git diff --check` -> clean
- `UV_CACHE_DIR=/tmp/uv-cache UV_PROJECT_ENVIRONMENT=/tmp/darwin-nic-venv uv run black --check tests/test_app.py tests/test_docs.py` -> clean

## Notes

`just check` is not a clean repo-wide signal yet because the existing formatter baseline wants to reformat 18 pre-existing files outside this slice. This PR avoids that broad reformat.
