### PR TITLE
Prepare v2.1 release readiness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,99 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  python:
+    name: Python checks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v8
+        with:
+          enable-cache: true
+
+      - name: Install Python
+        run: uv python install 3.14
+
+      - name: Sync dependencies
+        run: uv sync --extra dev --frozen
+
+      - name: Check formatting
+        run: uv run black --check src/ tests/
+
+      - name: Lint
+        run: uv run ruff check src/ tests/
+
+      - name: Type check
+        run: uv run mypy src/darwin_mgmt_nic
+
+      - name: Test with coverage
+        run: uv run python -m pytest -q --cov=darwin_mgmt_nic --cov-report=term-missing --cov-report=xml
+
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: coverage-xml
+          path: coverage.xml
+          if-no-files-found: ignore
+
+      - name: Build Python distributions
+        run: uv build
+
+      - name: Upload Python distributions
+        uses: actions/upload-artifact@v7
+        with:
+          name: python-dist
+          path: dist/*
+
+  docs:
+    name: Documentation build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v8
+        with:
+          enable-cache: true
+
+      - name: Install Python
+        run: uv python install 3.14
+
+      - name: Sync dependencies
+        run: uv sync --extra dev --frozen
+
+      - name: Build docs
+        run: uv run mkdocs build --strict
+
+  nix:
+    name: Nix flake check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+
+      - name: Check flake
+        run: nix flake check --print-build-logs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           enable-cache: true
 
@@ -69,7 +69,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           enable-cache: true
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           enable-cache: true
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,63 @@
+name: Deploy Docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - "mkdocs.yml"
+      - "pyproject.toml"
+      - "uv.lock"
+      - ".github/workflows/docs.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build docs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v8
+        with:
+          enable-cache: true
+
+      - name: Install Python
+        run: uv python install 3.14
+
+      - name: Sync dependencies
+        run: uv sync --extra dev --frozen
+
+      - name: Build MkDocs site
+        run: uv run mkdocs build --strict
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v6
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v5
+        with:
+          path: site
+
+  deploy:
+    name: Deploy docs
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,68 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to package, for manual dry-run validation"
+        required: false
+        type: string
+
+permissions:
+  contents: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build release artifacts
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.tag || github.ref }}
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v8
+        with:
+          enable-cache: true
+
+      - name: Install Python
+        run: uv python install 3.14
+
+      - name: Sync dependencies
+        run: uv sync --extra dev --frozen
+
+      - name: Run tests
+        run: uv run python -m pytest -q
+
+      - name: Build distributions
+        run: uv build
+
+      - name: Smoke test wheel install
+        run: |
+          set -euo pipefail
+          uv venv --python 3.14 .release-venv
+          uv pip install --python .release-venv dist/*.whl
+          .release-venv/bin/darwin-nic --version
+
+      - name: Upload distributions
+        uses: actions/upload-artifact@v7
+        with:
+          name: python-dist
+          path: dist/*
+
+      - name: Publish GitHub Release
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v3
+        with:
+          name: DarwinNicUtil ${{ github.ref_name }}
+          generate_release_notes: true
+          files: dist/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
           ref: ${{ inputs.tag || github.ref }}
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           enable-cache: true
 

--- a/.github/workflows/secret-detection.yml
+++ b/.github/workflows/secret-detection.yml
@@ -1,0 +1,49 @@
+name: Secret Detection
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: "17 9 * * 1"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  gitleaks:
+    name: Gitleaks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Install gitleaks
+        run: |
+          set -euo pipefail
+          version="8.30.1"
+          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${version}/gitleaks_${version}_linux_x64.tar.gz" \
+            | tar xz -C /usr/local/bin gitleaks
+
+      - name: Run gitleaks
+        run: gitleaks detect --source . --config .gitleaks.toml --verbose --exit-code 1
+
+  trufflehog:
+    name: TruffleHog
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: TruffleHog scan
+        uses: trufflesecurity/trufflehog@v3.95.2
+        with:
+          extra_args: --only-verified

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ env/
 .coverage
 .coverage.*
 htmlcov/
+site/
 test-report.html
 .tox/
 .nox/

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,13 @@
+# gitleaks configuration for DarwinNicUtil
+# Secret scanning runs in CI and can be run locally with:
+#   gitleaks detect --source . --config .gitleaks.toml --verbose
+
+title = "DarwinNicUtil gitleaks config"
+
+[allowlist]
+  description = "Repository-specific false positives"
+  regexTarget = "line"
+  regexes = [
+    # Nix store paths and hashes are content addresses, not credentials.
+    '''/nix/store/[a-z0-9]{32}-''',
+  ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,51 @@
+# Changelog
+
+All notable changes to DarwinNicUtil are recorded here.
+
+## Unreleased
+
+### CI/CD
+
+- Add GitHub Actions CI, docs deployment, secret scanning, and release workflow scaffolding.
+- Add repo-local gitleaks configuration.
+- Add git-cliff changelog configuration.
+
+### Documentation
+
+- Add a release sprint plan for the v2.1.0 readiness push.
+- Include the release sprint plan in the MkDocs navigation.
+- Refresh the quickstart around current Nix, uv, and source-based startup flows.
+- Add a generic bastion/OOB operator guide and `llms.txt` repo summary.
+- Add artifact policy documentation for wheel/source distributions, Nix packages, MkDocs, and non-primary binary/PyPI surfaces.
+- Tighten README and MkDocs wording for accuracy, brevity, and generic repository boundaries.
+- Correct stale architecture references to removed or nonexistent entry points.
+
+### Testing
+
+- Add focused settings tests for TOML schema serialization, merge precedence, env overrides, profile selection, malformed config handling, and `init-config`.
+- Add app-level command tests for status, dashboard, test, restore, config display, profile listing, init-config, and main subcommand dispatch.
+- Add CLI backend tests for parser defaults, config/profile display, profile-driven configuration, platform failure, VPN repair, and error return paths.
+- Add Linux placeholder and network-manager tests covering carrier status, ping handling, service-order parsing, Wi-Fi metrics, interface scoring, route helpers, and interference heuristics.
+- Add an initial 40% coverage gate.
+
+### Fixed
+
+- Ensure app-level `configure` propagates backend exit codes.
+- Keep dry-run mode from applying Wi-Fi service-order preservation before interface validation.
+
+### Maintenance
+
+- Add MkDocs packages to the development dependency extra so docs commands run through `uv run --extra dev`.
+- Update the Nix package homepage from the retired GitLab URL to the GitHub repository.
+
+## 2.0.0 - 2026-01-16
+
+### Features
+
+- Initial Darwin USB management NIC configurator release.
+
+### Subsequent Changes Since v2.0.0
+
+- Added Nix flake packaging, a Just task surface, and Home Manager / System Manager modules.
+- Updated README guidance for Just, Nix packaging, and Linux support.
+- Added bastion diagnostics for USB OOB, `scutil --nwi`, Tailscale system extension state, and macOS NECP drops.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to DarwinNicUtil are recorded here.
 
 ## Unreleased
 
+- No changes yet.
+
+## 2.1.0 - 2026-04-25
+
 ### CI/CD
 
 - Add GitHub Actions CI, docs deployment, secret scanning, and release workflow scaffolding.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to DarwinNicUtil are recorded here.
 - Add artifact policy documentation for wheel/source distributions, Nix packages, MkDocs, and non-primary binary/PyPI surfaces.
 - Tighten README and MkDocs wording for accuracy, brevity, and generic repository boundaries.
 - Correct stale architecture references to removed or nonexistent entry points.
+- Scope Sophos and ABR feature ideas as deferred spikes outside the v2.1.0 release readiness lane.
 
 ### Testing
 

--- a/README.md
+++ b/README.md
@@ -1,97 +1,91 @@
 # Darwin Management NIC Configurator
 
-Configure USB network interfaces for out-of-band management access with controller WiFi preservation.
+Configure a USB Ethernet adapter for out-of-band management without letting it
+take over normal Wi-Fi or tailnet connectivity.
 
-*do you regularly find yourself brazenly plugging random networky shit into random computers in the basement?  If the victim device is a mac, I am usually soon thereafter up a creek with borgled network configuration due to* ***various annoyances like abr (admin by request) sophos (so many, bleugh), paloalto (oof!), tailscale, nebula, random CNIs and other silly network things*** *running on the macs in my life.  if this sounds familiar, here we are*
+`darwin-nic` is aimed at bastion and bench workflows where a Mac needs a
+temporary management link to network gear while keeping its primary network
+path intact.
 
-## Usage
+## Status
+
+- macOS is the primary supported platform.
+- Linux support is experimental and currently limited.
+- Release artifacts are source distributions, wheels, and Nix packages.
+- The PyInstaller spec is retained for manual builds, but standalone binaries
+  are not the primary release artifact yet.
+
+## Quick Start
 
 ```bash
-# Using just (dev)
-just run setup
-just run configure --device-ip <ipv4> --laptop-ip <ipv4> --preserve-wifi
-just run status
+# Run from Nix without cloning
+nix run github:Jesssullivan/DarwinNicUtil -- status
+nix run github:Jesssullivan/DarwinNicUtil -- configure \
+  --device-ip <device-ipv4> \
+  --laptop-ip <usb-nic-ipv4> \
+  --mgmt-network <cidr> \
+  --preserve-wifi
 
-# Using uv directly
-uv run darwin-nic setup
-uv run darwin-nic configure --device-ip <ipv4> --laptop-ip <ipv4> --preserve-wifi
+# Run from a source checkout
+uv sync --extra dev
+uv run darwin-nic status
+uv run darwin-nic configure \
+  --device-ip <device-ipv4> \
+  --laptop-ip <usb-nic-ipv4> \
+  --mgmt-network <cidr> \
+  --preserve-wifi
+```
 
-# Using Nix (no clone needed)
-nix run github:Jesssullivan/DarwinNicUtil -- setup
-nix run github:Jesssullivan/DarwinNicUtil -- configure --device-ip <ipv4> --laptop-ip <ipv4>
+For repeated use, create a profile:
+
+```bash
+darwin-nic init-config
+darwin-nic config
+darwin-nic configure --profile homelab --preserve-wifi
 ```
 
 ## Install
 
 ```bash
-# Nix (profile install)
+# Nix profile
 nix profile install github:Jesssullivan/DarwinNicUtil
-
-# Nix (flake reference in your config)
-# inputs.darwin-nic.url = "github:Jesssullivan/DarwinNicUtil";
 
 # uv from source
 uv tool install .
 ```
 
-**Home Manager** and **System Manager** modules are also available -- see `nix/modules/` or use `just hm-apply` / `just sm-apply`.
-
+Home Manager and System Manager modules are available under `nix/modules/`.
 
 ## Commands
 
 | Command | Description |
 |---------|-------------|
 | `darwin-nic setup` | Interactive guided setup wizard |
-| `darwin-nic configure` | Configure USB NIC via CLI |
-| `darwin-nic status` | Show current network status |
-| `darwin-nic dashboard` | Real-time monitoring dashboard |
-| `darwin-nic test` | Test connectivity |
-| `darwin-nic restore` | Restore backup configuration |
-| `darwin-nic config` | Show current configuration and profiles |
+| `darwin-nic configure` | Configure a USB NIC |
+| `darwin-nic status` | Show interfaces, routes, and bastion diagnostics |
+| `darwin-nic dashboard` | Show network monitoring status |
+| `darwin-nic test` | Run basic connectivity checks |
+| `darwin-nic restore` | Restore saved network service order |
+| `darwin-nic config` | Show resolved settings and profiles |
 | `darwin-nic profiles` | List available profiles |
-| `darwin-nic init-config` | Initialize user config file |
-
-### Configure Options
-
-```bash
-darwin-nic configure \
-  --device-ip <ipv4> \      # Management device IP (required)
-  --laptop-ip <ipv4> \      # Your USB NIC IP (required)
-  --profile homelab \       # Use saved profile (optional)
-  --preserve-wifi \         # Preserve WiFi connectivity
-  --dry-run                 # Preview without changes
-```
+| `darwin-nic init-config` | Create a starter config file |
 
 ## Configuration
 
-Save your network settings in a TOML config file to avoid typing IPs every time.
-
-```bash
-# Initialize config file
-darwin-nic init-config
-
-# View current settings and profiles
-darwin-nic config
-
-# List available profiles
-darwin-nic profiles
-
-# Use a saved profile
-darwin-nic configure --profile homelab
-```
-
-### Config File Locations (in order of precedence)
+Settings are loaded in this order, with later sources overriding earlier ones:
 
 | Location | Purpose |
 |----------|---------|
 | `/etc/darwin-nic/config.toml` | System-wide defaults |
-| `~/.config/darwin-nic/config.toml` | User global settings |
-| `./.darwin-nic.toml` | Project/directory local override |
+| `~/.config/darwin-nic/config.toml` | User defaults |
+| `~/.darwin-nic.toml` | Legacy user config |
+| `./.darwin-nic.toml` | Directory-local override |
+| `./darwin-nic.toml` | Alternate directory-local override |
+| `DARWIN_NIC_*` | Environment overrides |
 
-### Example Config
+Example:
 
 ```toml
-# ~/.config/darwin-nic/config.toml
 default_profile = "homelab"
 
 [defaults]
@@ -101,92 +95,64 @@ preserve_wifi = true
 device_ip = "192.168.88.1"
 laptop_ip = "192.168.88.100"
 mgmt_network = "192.168.88.0/24"
-device_name = "CRS309 Bastion"
-
-[profiles.datacenter]
-device_ip = "10.200.0.1"
-laptop_ip = "10.200.0.100"
-mgmt_network = "10.200.0.0/24"
-device_name = "DC Core Switch"
+device_name = "Lab Management Device"
+device_type = "network"
 ```
 
-See `examples/config.toml` for a full example with all options.
+See `examples/config.toml` for a fuller profile example.
+
+## Bastion Notes
+
+For a generic `tailnet -> bastion host -> USB OOB NIC -> managed network
+device` flow:
+
+- keep `mgmt_network` aligned with the real management subnet;
+- use `darwin-nic status` before making privileged changes;
+- use `--dry-run` to preview interface and route changes;
+- pre-authenticate with `sudo -v` for non-interactive wrappers;
+- check `status` when raw or link-layer tools work but ordinary sockets fail.
+
+On macOS, `status` includes `scutil --nwi`, Tailscale system-extension state,
+and recent NECP socket-drop hints when available.
+
+Device-specific hostnames, credentials, OOB MAC addresses, and switch policy
+belong in downstream operator repositories, not in this generic tool.
+
+## Safety
+
+- Protected interfaces such as Wi-Fi, loopback, and system virtual links are
+  not modified.
+- `--preserve-wifi` keeps the primary network path ahead of the USB NIC.
+- Dry-run mode previews intended changes without applying them.
+- The emergency restore helper is available at `scripts/emergency-restore.sh`.
 
 ## Requirements
-- Python 3.13+ (3.14+ for native install, 3.13 via Nix)
-- USB-to-Ethernet adapter
-- macOS or Linux (yucky fruit OS or otherwise)
 
-### Supported USB Adapters
-
-Realtek, ASIX, Belkin, Apple USB Ethernet, StarTech, Cable Matters, TP-Link, and most generic USB LAN adapters.
-
-## Safety Features
-- **Protected Interfaces**: Never modifies en0 (WiFi), en1, or other critical interfaces
-- **WiFi Preservation**: Automatically maintains internet connectivity when configuring USB NICs
-- **USB Priority Prevention**: Prevents macOS from routing traffic through USB NIC
-- **Dry-Run Mode**: Preview all changes before applying
-- **Bastion Diagnostics**: `darwin-nic status` now surfaces USB OOB, `scutil --nwi`, Tailscale system-extension, and recent NECP-drop hints
-- Emergency Recovery, os noes!
-```bash
-./scripts/emergency-restore.sh
-```
-
-## Bastion / OOB Notes
-
-For a hardened `tailnet -> bastion host -> USB OOB NIC -> network gear` flow:
-
-- keep your profile `mgmt_network` aligned to the real OOB subnet, not the RFC5737 default
-- use `darwin-nic status` when ordinary sockets fail but raw tools still work
-- if the status output shows the USB interface missing from `scutil --nwi` while the Tailscale Network Extension is active, macOS may be blocking ordinary sockets with NECP even though link and ARP are healthy
-
-For CLI use, non-TUI `darwin-nic configure` now uses the normal interactive sudo path. If you want a non-interactive shell script, pre-authenticate first with `sudo -v` or provide your own wrapper.
-
-## Helpful stuff
-
-```bash
-# Check if adapter is recognized
-networksetup -listallhardwareports  # macOS
-ip link show                        # Linux
-
-# Inspect bastion/OOB status
-darwin-nic status
-
-# Run with verbose logging
-darwin-nic configure --device-ip <ipv4> --laptop-ip <ipv4> --dry-run
-```
+- Python 3.14+ for source and uv installs.
+- Nix for flake-based package usage.
+- A USB-to-Ethernet adapter.
+- macOS for the full current feature set.
 
 ## Development
 
-All dev tasks are managed via [`just`](https://github.com/casey/just):
+```bash
+just dev
+just check
+just test
+just docs-build
+uv build
+```
 
-| Recipe | Description |
-|--------|-------------|
-| `just dev` | Sync development dependencies |
-| `just run <args>` | Run darwin-nic in dev mode |
-| `just test` | Run tests with coverage |
-| `just lint` | Lint with ruff |
-| `just format` | Format with black |
-| `just type-check` | Type-check with mypy |
-| `just ci` | Run all checks (format + lint + type-check + test) |
-| `just build-nix` | Build with Nix |
-| `just build-wheel` | Build Python wheel |
-| `just nix-check` | Validate Nix flake |
-| `just shell` | Enter Nix development shell |
-| `just clean` | Remove build artifacts |
+Run `just` with no arguments to see all recipes.
 
-Run `just` with no arguments to see all available recipes.
+## Artifacts
 
+Current release artifacts are:
 
-## Future work:
-- [ ] Integrate with Outbot Harness
-- [ ] add publicly viewable mkdocs route
-- [x] ~~add brew packaging and multiarch installers~~ (Nix flake packaging done, brew TBD)
-- [ ] add multiarch binary installers
-- [ ] add IPC friendly installer patterns
-- [ ] add docs site, add IDE & llms.txt
-- [ ] Add to tinyland darwin pkg artifactory 
-- [ ] add desktop assets 
-- [ ] integrate upx compression 
-- [ ] Develop bridge module for multiple management connections and tunnels, ie. WAS-110 forwarding 
-- [ ] Revise rich logging flow for better log state TUI management 
+- Python wheel and source distribution from `uv build`;
+- Nix flake package outputs;
+- MkDocs site artifacts from the docs workflow.
+
+GitHub release and docs workflows are present for tag-based publication.
+PyPI publishing and standalone binary distribution remain tracked release
+follow-ups.

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,53 @@
+# git-cliff configuration for DarwinNicUtil
+# https://git-cliff.org/docs/configuration
+
+[changelog]
+header = """
+# Changelog
+
+All notable changes to DarwinNicUtil are recorded here.\n
+"""
+body = """
+{%- macro remote_url() -%}
+  https://github.com/Jesssullivan/DarwinNicUtil
+{%- endmacro -%}
+
+{% if version -%}
+    ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+{% else -%}
+    ## [Unreleased]
+{% endif -%}
+
+{% for group, commits in commits | group_by(attribute="group") %}
+    ### {{ group | striptags | trim | upper_first }}
+    {% for commit in commits %}
+        - {% if commit.scope %}**{{ commit.scope }}**: {% endif %}{{ commit.message | upper_first }}\
+          {% if commit.breaking %} (**BREAKING**){% endif %}\
+          ([{{ commit.id | truncate(length=7, end="") }}]({{ self::remote_url() }}/commit/{{ commit.id }}))
+    {%- endfor %}
+{% endfor %}
+"""
+trim = true
+footer = ""
+
+[git]
+conventional_commits = true
+filter_unconventional = false
+split_commits = false
+commit_parsers = [
+    { message = "^feat", group = "Features" },
+    { message = "^fix", group = "Bug Fixes" },
+    { message = "^docs", group = "Documentation" },
+    { message = "^test", group = "Testing" },
+    { message = "^ci", group = "CI/CD" },
+    { message = "^chore", group = "Maintenance" },
+    { message = "^refactor", group = "Refactoring" },
+    { message = "^style", group = "Styling" },
+    { message = "^perf", group = "Performance" },
+    { message = "^add", group = "Features" },
+    { message = "^Merge", skip = true },
+]
+protect_breaking_commits = false
+filter_commits = false
+tag_pattern = "v[0-9].*"
+sort_commits = "newest"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -19,7 +19,6 @@ graph TB
     subgraph Platform["Platform Detectors"]
         MACOS[MacOSUSBNICDetector]
         LINUX[LinuxUSBNICDetector]
-        WIN[WindowsUSBNICDetector]
     end
 
     subgraph Network["Network Management"]
@@ -33,7 +32,6 @@ graph TB
     CONF --> FACTORY
     FACTORY --> MACOS
     FACTORY --> LINUX
-    FACTORY --> WIN
     CONF --> SVC
     CONF --> WIFI
     DASH --> SVC
@@ -44,16 +42,18 @@ graph TB
 
 ```
 src/darwin_mgmt_nic/
-├── unified_entry.py    # Package entry point
-├── cli.py              # CLI argument parsing
-├── guided_setup.py     # Rich TUI wizard
+├── app.py              # Installed console-script entry point and subcommands
+├── cli.py              # Configure/status backend used by app.py and legacy runner
+├── guided_setup.py     # Rich guided setup wizard
+├── settings.py         # TOML/env profile loading
 ├── config.py           # Configuration models
 ├── configurator.py     # Main orchestration
 ├── factory.py          # Platform factory
 ├── detectors.py        # Abstract base class
 ├── macos.py            # macOS implementation
 ├── linux.py            # Linux placeholder
-└── network_manager.py  # Network utilities
+├── network_manager.py  # WiFi/service-order/routing utilities
+└── tui.py              # Terminal UI primitives
 ```
 
 ## Data Flow
@@ -210,6 +210,5 @@ classDiagram
 
 | Platform | Status | Detection Method |
 |----------|--------|------------------|
-| macOS | Complete | `networksetup -listallhardwareports` |
-| Linux | Planned | `ip link`, `nmcli` |
-| Windows | Planned | `netsh`, PowerShell |
+| macOS | Primary | `networksetup`, `ifconfig`, `route`, `scutil`, unified logs |
+| Linux | Experimental placeholder | `ip link`, `ping` |

--- a/docs/artifacts.md
+++ b/docs/artifacts.md
@@ -1,0 +1,71 @@
+# Artifacts
+
+This project currently treats wheel/source distributions, Nix packages, and the
+MkDocs site as release artifacts.
+
+## Python Packages
+
+Build locally with:
+
+```bash
+uv build
+```
+
+Expected outputs:
+
+```text
+dist/darwin_mgmt_nic_configurator-*.whl
+dist/darwin_mgmt_nic_configurator-*.tar.gz
+```
+
+Smoke-test a built wheel before publishing:
+
+```bash
+uv venv --python 3.14 .release-venv
+uv pip install --python .release-venv dist/*.whl
+.release-venv/bin/darwin-nic --version
+.release-venv/bin/darwin-nic --help
+rm -rf .release-venv
+```
+
+## Nix Packages
+
+Build the default CLI package:
+
+```bash
+nix build .#darwin-nic -L
+```
+
+The optional network-tools bundle is separate:
+
+```bash
+nix build .#net-utils -L
+```
+
+Downstream Home Manager users should consume the flake input and install
+`packages.${system}.darwin-nic`.
+
+## Documentation Site
+
+Build locally with:
+
+```bash
+uv run --extra dev mkdocs build --strict
+```
+
+The GitHub Pages workflow builds the same MkDocs site and publishes it as a
+Pages artifact.
+
+## GitHub Release
+
+The release workflow runs on tags matching `v*.*.*`. It builds `dist/*` and
+attaches the wheel and source distribution to the GitHub Release.
+
+## Not Yet Primary Artifacts
+
+| Surface | Current status |
+|---------|----------------|
+| PyPI | Planned through trusted publishing, not currently required for release |
+| Standalone binary | PyInstaller spec exists, but binary releases are not validated yet |
+| Homebrew | Not shipped |
+| Container image | Not applicable for the CLI today |

--- a/docs/bastion.md
+++ b/docs/bastion.md
@@ -1,0 +1,85 @@
+# Bastion / OOB Operator Flow
+
+`darwin-nic` supports the generic host-side part of a bastion path:
+
+```text
+tailnet -> bastion host -> USB OOB NIC -> managed network device
+```
+
+The tool configures the USB management NIC, keeps Wi-Fi or tailnet connectivity
+from being displaced, and surfaces host-local diagnostics when ordinary sockets
+behave differently from link-layer tools.
+
+## Profile Contract
+
+Use a profile for repeatable operator flows:
+
+```toml
+default_profile = "homelab"
+
+[defaults]
+preserve_wifi = true
+
+[profiles.homelab]
+device_ip = "192.168.88.1"
+laptop_ip = "192.168.88.100"
+mgmt_network = "192.168.88.0/24"
+device_name = "Lab Management Device"
+device_type = "network"
+description = "USB OOB management path"
+```
+
+Run:
+
+```bash
+darwin-nic status
+darwin-nic configure --profile homelab --preserve-wifi
+```
+
+The profile schema is intentionally generic. Device-specific hostnames,
+credentials, MAC addresses, and switch policy belong in the consuming operator
+runbook, not in DarwinNicUtil.
+
+## Sudo Contract
+
+Non-TUI CLI mode uses the normal interactive sudo path. For automation, pre-authenticate first:
+
+```bash
+sudo -v
+darwin-nic configure --profile homelab --preserve-wifi
+```
+
+TUI-guided setup should only use privileged operations after pre-authentication
+or through an explicit operator prompt.
+
+## Status Diagnostics
+
+`darwin-nic status` reports the normal network dashboard and, when USB OOB state
+is present, bastion diagnostics:
+
+- USB interfaces with assigned management IPs;
+- interfaces visible to `scutil --nwi`;
+- USB interfaces missing from `scutil --nwi`;
+- whether the Tailscale system extension appears active;
+- whether recent macOS unified logs include outbound socket drops with `reason: NECP`.
+
+These diagnostics are meant to separate host-local policy issues from device or
+cabling issues. If link-layer tools work but TCP sockets fail with `No route to
+host`, check the `scutil --nwi` and NECP lines before re-debugging the managed
+device.
+
+## Boundaries
+
+DarwinNicUtil owns:
+
+- USB NIC detection and configuration;
+- Wi-Fi preservation and route/service-order safety;
+- dry-run/status output;
+- host-side bastion diagnostics.
+
+Consuming runbooks own:
+
+- target device identity;
+- credentials and secret loading;
+- device-specific recovery commands;
+- topology-specific access tiers.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -96,6 +96,8 @@ Shows:
 - WiFi status
 - USB NIC status
 - Service order
+- Bastion/OOB diagnostics on macOS when relevant, including `scutil --nwi`,
+  Tailscale system-extension state, and recent NECP drop hints
 
 ## darwin-nic dashboard
 
@@ -206,8 +208,8 @@ preserve_wifi = true
 device_ip = "192.168.88.1"
 laptop_ip = "192.168.88.100"
 mgmt_network = "192.168.88.0/24"
-device_name = "CRS309 Bastion"
-description = "Home lab network"
+device_name = "Lab Management Device"
+description = "Home lab management network"
 
 [profiles.datacenter]
 device_ip = "10.200.0.1"

--- a/docs/development.md
+++ b/docs/development.md
@@ -3,238 +3,116 @@
 ## Setup
 
 ```bash
-# Clone repository
 git clone https://github.com/Jesssullivan/DarwinNicUtil.git
 cd DarwinNicUtil
 
-# Create virtual environment (Python 3.14+)
-python3 -m venv venv
-source venv/bin/activate
-
-# Install with dev dependencies
-pip install -e ".[dev]"
+uv sync --extra dev
 ```
+
+Python 3.14+ is required for source-based development. The Nix package provides
+its own interpreter.
 
 ## Project Structure
 
-```
+```text
 DarwinNicUtil/
-├── darwin-nic              # Main entry point
-├── darwin-nic-venv         # Venv wrapper
-├── src/darwin_mgmt_nic/    # Source code
-├── tests/                  # Test suite
-├── docs/                   # Documentation
-├── pyproject.toml          # Project config
+├── darwin-nic              # Legacy bootstrap runner
+├── src/darwin_mgmt_nic/    # Runtime package
+├── tests/                  # Unit and docs tests
+├── docs/                   # MkDocs site
+├── nix/                    # Nix package, overlay, and modules
+├── .github/workflows/      # GitHub CI, docs, release, and secret scans
+├── pyproject.toml          # Python package and tooling config
 └── mkdocs.yml              # Docs config
 ```
 
-## Commands
+## Common Commands
 
-```mermaid
-flowchart LR
-    subgraph Lint
-        BLACK[black src/ tests/]
-        RUFF[ruff check src/ tests/]
-        MYPY[mypy src/darwin_mgmt_nic]
-    end
+| Command | Purpose |
+|---------|---------|
+| `just dev` | Sync development dependencies |
+| `just run <args>` | Run `darwin-nic` from the checkout |
+| `just check` | Run format check, Ruff, and mypy |
+| `just test` | Run pytest with coverage |
+| `just docs-build` | Build MkDocs locally |
+| `just build-wheel` | Build wheel and source distribution |
+| `just nix-check` | Run `nix flake check` |
 
-    subgraph Test
-        PYTEST[./scripts/run_tests.sh]
-    end
-
-    subgraph Build
-        BINARY[./scripts/build.sh]
-        WHEEL[python -m build]
-    end
-```
-
-### Linting
+Direct equivalents:
 
 ```bash
-# Format code
-black src/ tests/
-
-# Lint code
-ruff check src/ tests/
-
-# Type check
-mypy src/darwin_mgmt_nic
+uv run black --check src/ tests/
+uv run ruff check src/ tests/
+uv run mypy src/darwin_mgmt_nic
+uv run pytest --cov=darwin_mgmt_nic --cov-report=term-missing
+uv run mkdocs build --strict
+uv build
 ```
 
-### Testing
+## Test Policy
+
+Runtime changes should include focused tests near the touched surface. The
+current coverage gate starts at 40 percent and should ratchet upward as the
+large TUI and network-manager surfaces become better covered.
+
+Useful focused runs:
 
 ```bash
-# Run all tests with coverage
-./scripts/run_tests.sh
-
-# Run specific test
-pytest tests/test_config.py::TestNetworkConfig::test_validation -v
-
-# Run with verbose output
-pytest tests/ -v --tb=short
+uv run --extra dev python -m pytest -q
+uv run --extra dev python -m pytest tests/test_settings.py -q
+uv run --extra dev python -m pytest tests/test_app.py -q
 ```
 
-### Building
-
-```bash
-# Build PyInstaller binary
-./scripts/build.sh
-
-# Build wheel
-python -m build
-```
+Tests mock system commands. Do not require live USB adapters, privileged network
+mutation, Tailscale, or downstream switch access in the unit suite.
 
 ## Code Style
 
 | Rule | Value |
 |------|-------|
 | Line length | 120 characters |
-| Python version | 3.14+ (PEP 750) |
+| Runtime target | Python 3.14+ |
 | Formatter | Black |
 | Linter | Ruff |
-| Type checker | mypy (strict) |
+| Type checker | mypy strict mode |
 
-### Type Hints
+Use typed functions for new runtime code. Keep comments short and reserve them
+for command parsing, privilege boundaries, or platform-specific behavior that is
+not obvious from the code.
 
-All functions require type hints:
+## CI
 
-```python
-def configure_interface(
-    interface: str,
-    ip_address: str,
-    netmask: str = "255.255.255.0"
-) -> bool:
-    """Configure network interface."""
-    ...
-```
+GitHub Actions now own the public validation path:
 
-### Dataclasses
+| Workflow | Purpose |
+|----------|---------|
+| `ci.yml` | Format, lint, type-check, tests, docs build, package build |
+| `secret-detection.yml` | Gitleaks and TruffleHog scanning |
+| `docs.yml` | MkDocs build and GitHub Pages artifact upload |
+| `release.yml` | Tag-triggered wheel/source distribution and GitHub Release |
 
-Use frozen dataclasses with slots:
-
-```python
-@dataclass(frozen=True, slots=True)
-class NetworkConfig:
-    device_ip: str
-    laptop_ip: str
-    netmask: str = "255.255.255.0"
-```
-
-## Testing
-
-### Test Categories
-
-```mermaid
-pie title Test Distribution
-    "Config Models" : 16
-    "Detectors" : 7
-    "Factory" : 14
-    "macOS" : 16
-    "Configurator" : 12
-```
-
-### Writing Tests
-
-```python
-import pytest
-from darwin_mgmt_nic.config import NetworkConfig
-
-class TestNetworkConfig:
-    def test_valid_config(self):
-        config = NetworkConfig(
-            device_ip="192.0.2.1",
-            laptop_ip="192.0.2.100",
-            netmask="255.255.255.0",
-            mgmt_network="198.51.100.0/24",
-            device_name="Test"
-        )
-        assert config.device_ip == "192.0.2.1"
-
-    def test_invalid_ip_raises(self):
-        with pytest.raises(ValueError):
-            NetworkConfig(
-                device_ip="invalid",
-                laptop_ip="192.0.2.100",
-                ...
-            )
-```
-
-### Fixtures
-
-Common fixtures are in `tests/conftest.py`:
-
-```python
-@pytest.fixture
-def mock_networksetup(mocker):
-    """Mock networksetup command output."""
-    return mocker.patch("subprocess.run", ...)
-```
-
-## CI/CD Pipeline
-
-```mermaid
-flowchart LR
-    subgraph Lint Stage
-        L1[black]
-        L2[ruff]
-        L3[mypy]
-    end
-
-    subgraph Test Stage
-        T1[pytest]
-        T2[SAST]
-        T3[Secret Detection]
-    end
-
-    subgraph Build Stage
-        B1[PyInstaller Binary]
-        B2[Python Wheel]
-    end
-
-    subgraph Pages Stage
-        P1[MkDocs Build]
-    end
-
-    L1 --> T1
-    L2 --> T1
-    L3 --> T1
-    T1 --> B1
-    T2 --> B1
-    T3 --> B1
-    B1 --> P1
-    B2 --> P1
-```
-
-## Contributing
-
-1. Fork the repository
-2. Create feature branch: `git checkout -b feature/amazing-feature`
-3. Make changes
-4. Add tests
-5. Run linting: `black . && ruff check .`
-6. Run tests: `./scripts/run_tests.sh`
-7. Commit: `git commit -m 'Add amazing feature'`
-8. Push: `git push origin feature/amazing-feature`
-9. Open a pull request
-
-### Commit Messages
-
-Use conventional commits:
-
-- `feat:` New feature
-- `fix:` Bug fix
-- `docs:` Documentation
-- `refactor:` Code refactoring
-- `test:` Test changes
-- `chore:` Maintenance
+GitLab CI remains in the repository for compatibility, but GitHub is the
+release-facing surface.
 
 ## Releasing
 
+Before tagging:
+
 ```bash
-# Update version in pyproject.toml
-# Create tag
+just check
+uv run --extra dev python -m pytest -q
+uv run --extra dev mkdocs build --strict
+uv build
+nix flake check
+```
+
+Then tag from a clean, reviewed branch:
+
+```bash
 git tag -a v2.1.0 -m "Release v2.1.0"
 git push origin v2.1.0
-
-# CI will build and publish artifacts
 ```
+
+The release workflow attaches `dist/*` to the GitHub Release. PyPI trusted
+publishing and standalone binary distribution are follow-up release tasks unless
+they are explicitly enabled before the tag.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,56 +1,69 @@
 # Darwin Management NIC Configurator
 
-Configure USB network interfaces for out-of-band management access with automatic WiFi preservation.
+`darwin-nic` configures a USB Ethernet adapter for out-of-band management while
+preserving the host's normal Wi-Fi and tailnet path.
 
-## Features
+## What It Owns
 
-- **Single Binary** - No Python environment required
-- **WiFi Preservation** - Maintains internet connectivity during USB NIC setup
-- **Hardware-Aware** - MacBook model detection and optimal port recommendations
-- **Safety First** - Protected interfaces prevent accidental misconfiguration
+- USB NIC detection and ranking.
+- Static USB management addressing.
+- Wi-Fi/service-order preservation.
+- Dry-run and status output before privileged changes.
+- Bastion diagnostics for route state, `scutil --nwi`, Tailscale extension
+  state, and recent macOS NECP socket drops.
+
+Device-specific topology, credentials, switch commands, and recovery policy
+belong in downstream operator repositories.
 
 ## Quick Start
 
 ```bash
-# Interactive setup (recommended)
-./darwin-nic setup
-
-# CLI configuration
-./darwin-nic configure --device-ip 192.0.2.1 --laptop-ip 192.0.2.100 --preserve-wifi
+nix run github:Jesssullivan/DarwinNicUtil -- status
+nix run github:Jesssullivan/DarwinNicUtil -- configure \
+  --device-ip 192.168.88.1 \
+  --laptop-ip 192.168.88.100 \
+  --mgmt-network 192.168.88.0/24 \
+  --preserve-wifi
 ```
 
-## How It Works
+From a checkout:
+
+```bash
+uv sync --extra dev
+uv run darwin-nic setup
+uv run darwin-nic status
+```
+
+## Workflow
 
 ```mermaid
 flowchart LR
-    A[USB NIC Plugged In] --> B{Detect Interface}
-    B --> C[Score & Rank NICs]
-    C --> D[Configure Selected NIC]
-    D --> E[Preserve WiFi Priority]
-    E --> F[Test Connectivity]
+    A[USB NIC plugged in] --> B[Detect safe candidate]
+    B --> C[Apply profile or CLI IPs]
+    C --> D[Preserve Wi-Fi priority]
+    D --> E[Add management route]
+    E --> F[Report status and diagnostics]
 ```
 
-## Use Cases
+## Main Commands
 
 | Scenario | Command |
 |----------|---------|
-| First-time setup | `darwin-nic setup` |
-| Use saved profile | `darwin-nic configure --profile homelab` |
-| Quick configure | `darwin-nic configure --device-ip 192.0.2.1 --laptop-ip 192.0.2.100` |
-| View config | `darwin-nic config` |
-| Check status | `darwin-nic status` |
-| Monitor network | `darwin-nic dashboard` |
+| Guided setup | `darwin-nic setup` |
+| Profile-based setup | `darwin-nic configure --profile homelab --preserve-wifi` |
+| One-off setup | `darwin-nic configure --device-ip 192.168.88.1 --laptop-ip 192.168.88.100 --mgmt-network 192.168.88.0/24` |
+| Inspect state | `darwin-nic status` |
+| List profiles | `darwin-nic profiles` |
 
-## Requirements
+## Platform Status
 
-- macOS (Darwin) - Linux support planned
-- Python 3.14+
-- USB-to-Ethernet adapter
+| Platform | Status |
+|----------|--------|
+| macOS | Primary supported platform |
+| Linux | Experimental placeholder support |
 
-## Supported Adapters
+## Artifacts
 
-Realtek, ASIX, Belkin, Apple USB Ethernet, StarTech, Cable Matters, TP-Link, and generic USB LAN adapters.
-
-## License
-
-zlib License - Copyright (c) 2024-2025 Contributors
+The release path currently supports Python wheel/source distributions, Nix
+packages, and MkDocs site artifacts. Standalone binary and PyPI publication are
+tracked follow-ups rather than established release outputs.

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,0 +1,27 @@
+# DarwinNicUtil
+
+DarwinNicUtil is a Python CLI for configuring USB network interfaces for
+out-of-band management access while preserving Wi-Fi and tailnet connectivity.
+
+Primary docs:
+
+- `README.md`: install, usage, safety features, and development commands.
+- `docs/quickstart.md`: current Nix, source, and uv tool startup flows.
+- `docs/cli.md`: command and option reference.
+- `docs/bastion.md`: generic bastion/OOB operator flow and boundaries.
+- `docs/artifacts.md`: current release artifact policy.
+- `docs/architecture.md`: module structure and safety architecture.
+- `docs/superpowers/release-sprint-plan.md`: release-readiness sprint plan.
+
+Important boundaries:
+
+- This repo owns generic USB NIC setup, routing behavior, sudo behavior, and
+  host-side diagnostics.
+- Device-specific topology, credentials, MAC addresses, and switch policy belong
+  in consuming operator runbooks.
+- The generic bastion commands are:
+
+```bash
+darwin-nic status
+darwin-nic configure --profile homelab --preserve-wifi
+```

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,43 +1,47 @@
 # Quick Start
 
-Get up and running in under 5 minutes.
+Get a USB management NIC configured without letting it take over normal Wi-Fi or tailnet connectivity.
 
 ## Installation
 
-=== "Clone & Run"
+=== "Nix"
+
+    ```bash
+    nix run github:Jesssullivan/DarwinNicUtil -- setup
+
+    nix run github:Jesssullivan/DarwinNicUtil -- configure \
+      --device-ip 192.168.88.1 \
+      --laptop-ip 192.168.88.100 \
+      --mgmt-network 192.168.88.0/24 \
+      --preserve-wifi
+    ```
+
+=== "Source"
 
     ```bash
     git clone https://github.com/Jesssullivan/DarwinNicUtil.git
     cd DarwinNicUtil
 
-    python3 -m venv venv
-    source venv/bin/activate
-    pip install -e .
-
-    ./darwin-nic setup
+    uv sync --extra dev
+    uv run darwin-nic setup
     ```
 
-=== "Venv Wrapper"
+=== "uv Tool"
 
     ```bash
-    # Automatically activates venv and installs dependencies
-    ./darwin-nic-venv setup
-    ```
+    git clone https://github.com/Jesssullivan/DarwinNicUtil.git
+    cd DarwinNicUtil
 
-=== "Binary (No Python)"
-
-    ```bash
-    # Download pre-built binary from releases
-    chmod +x darwin-nic
-    ./darwin-nic setup
+    uv tool install .
+    darwin-nic setup
     ```
 
 ## Interactive Setup
 
-The guided setup wizard walks you through the entire process:
+The guided setup wizard walks through USB NIC detection, IP configuration, Wi-Fi preservation, and a connectivity check.
 
 ```bash
-./darwin-nic setup
+darwin-nic setup
 ```
 
 ```mermaid
@@ -48,17 +52,18 @@ sequenceDiagram
 
     U->>D: darwin-nic setup
     D->>N: Scan for USB NICs
-    N-->>D: Found en7 (USB 10/100/1000 LAN)
+    N-->>D: Found en7 (USB Ethernet)
     D->>U: Confirm interface?
     U->>D: Yes
     D->>N: Configure IP
-    D->>N: Preserve WiFi priority
-    D-->>U: Success!
+    D->>N: Preserve Wi-Fi priority
+    D->>N: Test target reachability
+    D-->>U: Complete
 ```
 
 ## Configuration File
 
-Save your network settings to avoid typing IPs every time:
+Save network settings to avoid typing IPs every time:
 
 ```bash
 # Initialize config file
@@ -76,25 +81,32 @@ Edit `~/.config/darwin-nic/config.toml`:
 ```toml
 default_profile = "homelab"
 
+[defaults]
+preserve_wifi = true
+
 [profiles.homelab]
 device_ip = "192.168.88.1"
 laptop_ip = "192.168.88.100"
 mgmt_network = "192.168.88.0/24"
-device_name = "CRS309 Bastion"
+device_name = "Lab Management Device"
+device_type = "network"
+```
+
+Then run:
+
+```bash
+darwin-nic configure --profile homelab --preserve-wifi
 ```
 
 ## CLI Configuration
 
-For scripting or quick configuration:
+For scripting or one-off setup:
 
 ```bash
-# Use a saved profile
-darwin-nic configure --profile homelab
-
-# Or specify IPs directly
 darwin-nic configure \
-  --device-ip 192.0.2.1 \
-  --laptop-ip 192.0.2.100 \
+  --device-ip 192.168.88.1 \
+  --laptop-ip 192.168.88.100 \
+  --mgmt-network 192.168.88.0/24 \
   --preserve-wifi
 ```
 
@@ -104,27 +116,28 @@ darwin-nic configure \
 |--------|-------------|---------|
 | `--profile` | Use named profile | - |
 | `--device-ip` | Management device IP | From config |
-| `--laptop-ip` | Your USB NIC IP | From config |
+| `--laptop-ip` | USB NIC IP to assign locally | From config |
 | `--netmask` | Network mask | `255.255.255.0` |
-| `--preserve-wifi` | Keep WiFi as primary | Off |
+| `--mgmt-network` | Management network CIDR | From config |
+| `--preserve-wifi` | Keep Wi-Fi as primary | Off |
 | `--dry-run` | Preview without changes | Off |
 
 ## Verify Configuration
 
 ```bash
-# Check status
-./darwin-nic status
+# Check status, routes, and bastion/OOB diagnostics
+darwin-nic status
 
 # Test connectivity
-./darwin-nic test
+darwin-nic test
 
 # Real-time monitoring
-./darwin-nic dashboard
+darwin-nic dashboard
 ```
 
 If `status` shows the USB interface missing from `scutil --nwi` while the
-Tailscale system extension is active, ordinary sockets may be getting blocked
-by macOS NECP even though the USB link itself is healthy.
+Tailscale system extension is active, ordinary sockets may be blocked by macOS
+NECP even though link-layer tools and ARP still work.
 
 ## Troubleshooting
 
@@ -140,7 +153,10 @@ networksetup -listallhardwareports
 ```bash
 # Pre-authenticate sudo, then rerun configure
 sudo -v
-./darwin-nic configure --device-ip 192.0.2.1 --laptop-ip 192.0.2.100
+darwin-nic configure \
+  --device-ip 192.168.88.1 \
+  --laptop-ip 192.168.88.100 \
+  --mgmt-network 192.168.88.0/24
 ```
 
 ### Emergency Recovery

--- a/docs/superpowers/release-sprint-plan.md
+++ b/docs/superpowers/release-sprint-plan.md
@@ -1,0 +1,129 @@
+# Release Readiness Plan
+
+Date: 2026-04-25
+Target release: v2.1.0
+Status: Active branch plan
+
+## Goal
+
+Make DarwinNicUtil release-ready as a generic USB management NIC tool: tested,
+documented, packaged, scanned for secrets, and safe for bastion workflows.
+
+The supported generic operator path is:
+
+```text
+tailnet -> bastion host -> USB OOB NIC -> managed network device
+```
+
+Switch hostnames, credentials, OOB MAC addresses, RouterOS commands, and
+site-specific recovery policy remain outside this repository.
+
+## Current Branch State
+
+| Surface | Status |
+|---------|--------|
+| Tests | Unit suite is green with coverage above the configured 40 percent gate |
+| CI | GitHub Actions now cover CI, docs, secret scans, and tag releases |
+| Docs | MkDocs includes quickstart, architecture, CLI, bastion, artifacts, and this plan |
+| Packaging | Wheel/source distribution and Nix package paths are present |
+| Security | Repo-local gitleaks config and scan workflow are present |
+| Changelog | `CHANGELOG.md` records work since `v2.0.0` |
+
+## Release Contract
+
+Keep these public interfaces stable for v2.1.0:
+
+- `darwin-nic = "darwin_mgmt_nic.app:main"`
+- `darwin-nic configure --device-ip <ip> --laptop-ip <ip> --preserve-wifi`
+- `darwin-nic configure --profile <name> --preserve-wifi`
+- `darwin-nic status`
+- `~/.config/darwin-nic/config.toml`
+- `packages.${system}.darwin-nic`
+- `packages.${system}.net-utils` as an optional Nix output
+
+The TOML profile schema remains:
+
+```toml
+default_profile = "homelab"
+
+[defaults]
+preserve_wifi = true
+dry_run = false
+show_dashboard = false
+
+[profiles.homelab]
+device_ip = "192.168.88.1"
+laptop_ip = "192.168.88.100"
+mgmt_network = "192.168.88.0/24"
+device_name = "Lab Management Device"
+device_type = "network"
+```
+
+Profile names and values are examples only. Downstream repos own their own
+device names, policies, and secrets.
+
+## Remaining Work
+
+| Priority | Task | Done When |
+|----------|------|-----------|
+| P0 | Final docs/readme accuracy pass | README and MkDocs no longer overpromise binaries, PyPI, Homebrew, or Linux parity |
+| P0 | Release artifact smoke test | Wheel installs in a clean venv and `darwin-nic --help` works |
+| P0 | Nix validation | `nix flake check` passes with new docs and tests included |
+| P0 | Hardware dry-run | `darwin-nic status` and `configure --dry-run` are checked on a bastion Mac |
+| P1 | Close or split issue #4 | Shipped NECP diagnostics are documented; remaining hardware evidence is tracked |
+| P1 | Ratchet tests | Next target is 50 percent coverage after macOS/network-manager follow-ups |
+| P2 | PyPI trusted publishing | Trusted publisher is configured and release workflow publishes packages |
+| P2 | Binary installer decision | Either validate PyInstaller releases or document them as unsupported |
+| P3 | Sophos and ABR spikes | Issues #2 and #3 are scoped separately from v2.1.0 release readiness |
+
+## Validation Checklist
+
+Run before tagging:
+
+```bash
+just check
+uv run --extra dev python -m pytest -q
+uv run --extra dev mkdocs build --strict
+uv build
+nix flake check --print-build-logs
+```
+
+Optional but recommended:
+
+```bash
+nix run nixpkgs#actionlint -- -color
+nix run nixpkgs#gitleaks -- detect --source . --config .gitleaks.toml --verbose --exit-code 1
+```
+
+Hardware validation:
+
+```bash
+darwin-nic status
+darwin-nic configure --profile homelab --preserve-wifi --dry-run
+```
+
+Record skipped hardware checks as release risks rather than silently treating
+them as complete.
+
+## Artifacts
+
+The v2.1.0 release should publish:
+
+- wheel and source distribution from `uv build`;
+- GitHub Release notes and attached `dist/*` artifacts;
+- MkDocs site through GitHub Pages;
+- Nix package availability through the flake.
+
+PyPI publication is desirable but can follow the GitHub Release if trusted
+publisher setup is not ready.
+
+## Risks
+
+| Risk | Mitigation |
+|------|------------|
+| CLI sudo behavior differs over SSH or wrappers | Document `sudo -v` pre-authentication and manually validate on hardware |
+| Docs leak downstream topology or credentials | Keep examples generic and enforce docs boundary tests |
+| TOML schema drift breaks Home Manager consumers | Treat profile schema as release contract and cover it with settings tests |
+| Nix output drift breaks downstream flakes | Keep `packages.${system}.darwin-nic` stable |
+| Host policy blocks normal sockets despite healthy L2 | Keep NECP/Tailscale diagnostics visible in `status` |
+| CI and local commands diverge | Keep workflows aligned with `just`/`uv` validation commands |

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -6,9 +6,11 @@
 # CONFIG SEARCH ORDER (later overrides earlier):
 #   1. /etc/darwin-nic/config.toml       (system-wide)
 #   2. ~/.config/darwin-nic/config.toml  (user global)
-#   3. ./.darwin-nic.toml                (local directory)
-#   4. DARWIN_NIC_* environment vars
-#   5. CLI arguments
+#   3. ~/.darwin-nic.toml                (legacy user config)
+#   4. ./.darwin-nic.toml                (local directory)
+#   5. ./darwin-nic.toml                 (alternate local directory)
+#   6. DARWIN_NIC_* environment vars
+#   7. CLI arguments at runtime
 
 # Default profile to use when none specified
 default_profile = "homelab"
@@ -30,22 +32,22 @@ show_dashboard = false
 # ─────────────────────────────────────────────────────────────────────────────
 
 [profiles.homelab]
-# Primary home lab bastion switch
+# Primary lab management device
 device_ip = "192.168.88.1"
 laptop_ip = "192.168.88.100"
-mgmt_network = "192.168.10.0/24"
-device_name = "CRS309 Bastion"
-description = "Primary home lab management - MikroTik CRS309"
-device_type = "mikrotik"
+mgmt_network = "192.168.88.0/24"
+device_name = "Lab Management Device"
+description = "Primary lab management network"
+device_type = "network"
 
 [profiles.homelab-secondary]
-# Secondary switch reachable via bastion
+# Secondary device on the same management network
 device_ip = "192.168.88.2"
 laptop_ip = "192.168.88.100"
-mgmt_network = "192.168.10.0/24"
-device_name = "CRS310 Secondary"
-description = "Secondary switch - BiDi backhaul"
-device_type = "mikrotik"
+mgmt_network = "192.168.88.0/24"
+device_name = "Secondary Lab Device"
+description = "Secondary management target"
+device_type = "network"
 
 [profiles.datacenter]
 # Datacenter OOB management

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -51,9 +51,12 @@ markdown_extensions:
 nav:
   - Home: index.md
   - Quick Start: quickstart.md
+  - Bastion / OOB: bastion.md
+  - Artifacts: artifacts.md
   - Architecture: architecture.md
   - CLI Reference: cli.md
   - Development: development.md
+  - Release Sprint Plan: superpowers/release-sprint-plan.md
 
 extra:
   social:

--- a/nix/modules/home-manager.nix
+++ b/nix/modules/home-manager.nix
@@ -134,9 +134,9 @@ in
           homelab = {
             deviceIp = "192.168.88.1";
             laptopIp = "192.168.88.100";
-            mgmtNetwork = "192.168.10.0/24";
-            deviceName = "CRS309 Bastion";
-            deviceType = "mikrotik";
+            mgmtNetwork = "192.168.88.0/24";
+            deviceName = "Lab Management Device";
+            deviceType = "network";
           };
         }
       '';

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -6,7 +6,7 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "darwin-nic";
-  version = "2.0.0";
+  version = "2.1.0";
   pyproject = true;
 
   src = lib.cleanSource ./..;

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -49,7 +49,7 @@ python3Packages.buildPythonApplication rec {
 
   meta = {
     description = "USB network interface configurator for management access to network devices";
-    homepage = "https://gitlab.com/tinyland/projects/darwin-mgmt-nic-configurator";
+    homepage = "https://github.com/Jesssullivan/DarwinNicUtil";
     license = lib.licenses.zlib;
     maintainers = [ ];
     mainProgram = "darwin-nic";

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,9 @@ dev = [
     "black>=24.0.0",
     "ruff>=0.5.0",
     "mypy>=1.11.0",
+    "mkdocs>=1.6.0",
+    "mkdocs-material>=9.5.0",
+    "mkdocs-mermaid2-plugin>=1.1.0",
 ]
 
 [project.scripts]
@@ -65,7 +68,9 @@ packages = ["src/darwin_mgmt_nic"]
 
 [tool.black]
 line-length = 120
-target-version = ['py314']
+# Black does not yet expose a py314 target; keep formatter parsing on the
+# newest supported target while the package itself requires Python 3.14.
+target-version = ['py313']
 include = '\.pyi?$'
 extend-exclude = '''
 /(
@@ -84,6 +89,8 @@ extend-exclude = '''
 [tool.ruff]
 line-length = 120
 target-version = "py314"
+
+[tool.ruff.lint]
 select = [
     "E",   # pycodestyle errors
     "W",   # pycodestyle warnings
@@ -118,6 +125,7 @@ omit = [
 ]
 
 [tool.coverage.report]
+fail_under = 40
 exclude_lines = [
     "pragma: no cover",
     "def __repr__",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "darwin-mgmt-nic-configurator"
-version = "2.0.0"
+version = "2.1.0"
 description = "Darwin USB network interface configurator for management access to network devices"
 readme = "README.md"
 requires-python = ">=3.14"

--- a/src/darwin_mgmt_nic/__init__.py
+++ b/src/darwin_mgmt_nic/__init__.py
@@ -8,10 +8,10 @@ Version 2.0.0 - Python 3.14+ with modern type system
 __version__ = "2.0.0"
 
 from .config import NetworkConfig, NetworkInterface
+from .configurator import USBNICConfigurator
 from .detectors import USBNICDetector
 from .factory import USBNICDetectorFactory
-from .configurator import USBNICConfigurator
-from .settings import Settings, load_settings, init_config
+from .settings import Settings, init_config, load_settings
 
 __all__ = [
     "NetworkConfig",

--- a/src/darwin_mgmt_nic/__init__.py
+++ b/src/darwin_mgmt_nic/__init__.py
@@ -2,10 +2,10 @@
 USB Network Interface Configurator Package
 USB NIC detection and configuration with factory pattern
 
-Version 2.0.0 - Python 3.14+ with modern type system
+Version 2.1.0 - Python 3.14+ with modern type system
 """
 
-__version__ = "2.0.0"
+__version__ = "2.1.0"
 
 from .config import NetworkConfig, NetworkInterface
 from .configurator import USBNICConfigurator

--- a/src/darwin_mgmt_nic/app.py
+++ b/src/darwin_mgmt_nic/app.py
@@ -11,7 +11,7 @@ import logging
 import re
 import subprocess
 import sys
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from .settings import Settings, get_config_paths, init_config, load_settings
 
@@ -74,8 +74,7 @@ def cmd_configure(args: argparse.Namespace, settings: Settings) -> int | None:
     if args.show_dashboard:
         sys.argv.append("--show-dashboard")
 
-    cli_main()
-    return None
+    return cli_main()
 
 
 def cmd_setup(args: argparse.Namespace) -> None:
@@ -111,7 +110,7 @@ def cmd_status(args: argparse.Namespace) -> None:
     print_bastion_diagnostics(console)
 
 
-def print_bastion_diagnostics(console, detector=None) -> None:
+def print_bastion_diagnostics(console: Any, detector: Any = None) -> None:
     """Print high-signal bastion/OOB diagnostics when USB management state exists."""
     from rich.panel import Panel
     from rich.table import Table
@@ -161,9 +160,7 @@ def print_bastion_diagnostics(console, detector=None) -> None:
             "while the Tailscale Network Extension is active. Ordinary sockets may be blocked."
         )
     if diagnostics.recent_necp_drop:
-        console.print(
-            "[yellow]Warning:[/yellow] Recent macOS logs show `reason: NECP` drops for outbound sockets."
-        )
+        console.print("[yellow]Warning:[/yellow] Recent macOS logs show `reason: NECP` drops for outbound sockets.")
 
 
 def cmd_dashboard(args: argparse.Namespace) -> None:
@@ -196,9 +193,7 @@ def cmd_test(args: argparse.Namespace) -> None:
     interfaces = ["en0", "en1", "en11"]
     for interface in interfaces:
         try:
-            result = subprocess.run(
-                ["ifconfig", interface], capture_output=True, text=True
-            )
+            result = subprocess.run(["ifconfig", interface], capture_output=True, text=True)
             if result.returncode == 0:
                 table.add_row(f"Interface {interface}", "[OK] Active", "N/A")
             else:
@@ -209,14 +204,10 @@ def cmd_test(args: argparse.Namespace) -> None:
     test_ips = ["192.0.2.1", "192.168.1.1", "8.8.8.8"]
     for ip in test_ips:
         try:
-            result = subprocess.run(
-                ["ping", "-c", "1", "-W", "2", ip], capture_output=True, text=True
-            )
+            result = subprocess.run(["ping", "-c", "1", "-W", "2", ip], capture_output=True, text=True)
             if result.returncode == 0:
                 time_match = re.search(r"time=(\d+\.?\d*)", result.stdout)
-                response_time = (
-                    time_match.group(1) + " ms" if time_match else "Unknown"
-                )
+                response_time = time_match.group(1) + " ms" if time_match else "Unknown"
                 table.add_row(ip, "[OK] Reachable", response_time)
             else:
                 table.add_row(ip, "[--] Unreachable", "Timeout")
@@ -292,12 +283,8 @@ def cmd_show_config(settings: Settings) -> None:
         profiles_table.add_column("Device Name", style="dim")
 
         for name, profile in settings.profiles.items():
-            default_marker = (
-                " [yellow]*[/yellow]" if name == settings.default_profile else ""
-            )
-            profiles_table.add_row(
-                f"{name}{default_marker}", profile.device_ip, profile.device_name
-            )
+            default_marker = " [yellow]*[/yellow]" if name == settings.default_profile else ""
+            profiles_table.add_row(f"{name}{default_marker}", profile.device_ip, profile.device_name)
 
         console.print(profiles_table)
         console.print("[dim]* = default profile[/dim]")
@@ -322,17 +309,13 @@ def cmd_list_profiles(settings: Settings) -> None:
 
     if not settings.profiles:
         console.print("[yellow]No profiles configured.[/yellow]")
-        console.print(
-            "Run [cyan]darwin-nic init-config[/cyan] to create a config file."
-        )
+        console.print("Run [cyan]darwin-nic init-config[/cyan] to create a config file.")
         return
 
     console.print("[bold cyan]Available Profiles[/bold cyan]\n")
 
     for name, profile in settings.profiles.items():
-        default = (
-            " [yellow](default)[/yellow]" if name == settings.default_profile else ""
-        )
+        default = " [yellow](default)[/yellow]" if name == settings.default_profile else ""
         console.print(f"[bold]{name}[/bold]{default}")
         console.print(f"  Device: {profile.device_name}")
         console.print(f"  IP: {profile.device_ip} -> {profile.laptop_ip}")
@@ -370,9 +353,7 @@ Examples:
 
     # Configure command
     configure_parser = subparsers.add_parser("configure", help="Configure USB NIC")
-    configure_parser.add_argument(
-        "--profile", metavar="NAME", help="Use named profile from config file"
-    )
+    configure_parser.add_argument("--profile", metavar="NAME", help="Use named profile from config file")
     configure_parser.add_argument(
         "--device-ip",
         default="__PROFILE__",
@@ -383,38 +364,20 @@ Examples:
         default="__PROFILE__",
         help="Laptop USB NIC IP (required unless using --profile)",
     )
-    configure_parser.add_argument(
-        "--netmask", default="255.255.255.0", help="Network mask"
-    )
-    configure_parser.add_argument(
-        "--mgmt-network", default="198.51.100.0/24", help="Management network"
-    )
-    configure_parser.add_argument(
-        "--device-name", default="Network Device", help="Device name"
-    )
-    configure_parser.add_argument(
-        "--dry-run", action="store_true", help="Show what would be done"
-    )
-    configure_parser.add_argument(
-        "--preserve-wifi", action="store_true", help="Preserve WiFi connectivity"
-    )
-    configure_parser.add_argument(
-        "--show-dashboard", action="store_true", help="Show network dashboard"
-    )
+    configure_parser.add_argument("--netmask", default="255.255.255.0", help="Network mask")
+    configure_parser.add_argument("--mgmt-network", default="198.51.100.0/24", help="Management network")
+    configure_parser.add_argument("--device-name", default="Network Device", help="Device name")
+    configure_parser.add_argument("--dry-run", action="store_true", help="Show what would be done")
+    configure_parser.add_argument("--preserve-wifi", action="store_true", help="Preserve WiFi connectivity")
+    configure_parser.add_argument("--show-dashboard", action="store_true", help="Show network dashboard")
 
     # Other subcommands
     subparsers.add_parser("setup", help="Interactive guided setup")
     subparsers.add_parser("status", help="Show network status")
 
-    dashboard_parser = subparsers.add_parser(
-        "dashboard", help="Show monitoring dashboard"
-    )
-    dashboard_parser.add_argument(
-        "--interference", action="store_true", help="Monitor for interference"
-    )
-    dashboard_parser.add_argument(
-        "--duration", type=int, help="Monitoring duration in seconds"
-    )
+    dashboard_parser = subparsers.add_parser("dashboard", help="Show monitoring dashboard")
+    dashboard_parser.add_argument("--interference", action="store_true", help="Monitor for interference")
+    dashboard_parser.add_argument("--duration", type=int, help="Monitoring duration in seconds")
 
     subparsers.add_parser("test", help="Test connectivity")
     subparsers.add_parser("restore", help="Restore backup configuration")

--- a/src/darwin_mgmt_nic/cli.py
+++ b/src/darwin_mgmt_nic/cli.py
@@ -2,29 +2,26 @@
 CLI interface for USB NIC configurator
 """
 
-import sys
-import logging
 import argparse
+import logging
 import subprocess
+import sys
 import time
+
+from rich import box
 from rich.console import Console
 from rich.table import Table
-from rich import box
 
 from .config import NetworkConfig
 from .configurator import USBNICConfigurator
 from .factory import USBNICDetectorFactory
-from .settings import load_settings, init_config, get_config_paths, Settings
+from .settings import Settings, get_config_paths, init_config, load_settings
 
 
 def setup_logging(verbose: bool = False) -> None:
     """Configure logging based on verbosity"""
     level = logging.DEBUG if verbose else logging.INFO
-    logging.basicConfig(
-        level=level,
-        format='[%(asctime)s] %(levelname)s: %(message)s',
-        datefmt='%Y-%m-%d %H:%M:%S'
-    )
+    logging.basicConfig(level=level, format="[%(asctime)s] %(levelname)s: %(message)s", datefmt="%Y-%m-%d %H:%M:%S")
 
 
 def create_parser(settings: Settings) -> argparse.ArgumentParser:
@@ -48,103 +45,69 @@ Examples:
 
   # Initialize config file
   %(prog)s --init-config
-        """
+        """,
     )
 
     # Config management
-    parser.add_argument(
-        "--profile",
-        metavar="NAME",
-        help="Use named profile from config file"
-    )
+    parser.add_argument("--profile", metavar="NAME", help="Use named profile from config file")
 
-    parser.add_argument(
-        "--show-config",
-        action="store_true",
-        help="Show current configuration and available profiles"
-    )
+    parser.add_argument("--show-config", action="store_true", help="Show current configuration and available profiles")
 
-    parser.add_argument(
-        "--init-config",
-        action="store_true",
-        help="Initialize user config file with defaults"
-    )
+    parser.add_argument("--init-config", action="store_true", help="Initialize user config file with defaults")
 
-    parser.add_argument(
-        "--list-profiles",
-        action="store_true",
-        help="List available profiles"
-    )
+    parser.add_argument("--list-profiles", action="store_true", help="List available profiles")
 
     # Network configuration (defaults from settings)
     parser.add_argument(
         "--dry-run",
         action="store_true",
         default=settings.dry_run,
-        help="Show what would be done without making changes"
+        help="Show what would be done without making changes",
     )
 
     parser.add_argument(
-        "--device-ip",
-        default=settings.device_ip,
-        help=f"Device IP address (default: {settings.device_ip})"
+        "--device-ip", default=settings.device_ip, help=f"Device IP address (default: {settings.device_ip})"
     )
 
     parser.add_argument(
-        "--laptop-ip",
-        default=settings.laptop_ip,
-        help=f"Laptop IP address (default: {settings.laptop_ip})"
+        "--laptop-ip", default=settings.laptop_ip, help=f"Laptop IP address (default: {settings.laptop_ip})"
     )
 
-    parser.add_argument(
-        "--netmask",
-        default=settings.netmask,
-        help=f"Network mask (default: {settings.netmask})"
-    )
+    parser.add_argument("--netmask", default=settings.netmask, help=f"Network mask (default: {settings.netmask})")
 
     parser.add_argument(
         "--device-name",
         default=settings.device_name,
-        help=f"Human-readable device name (default: {settings.device_name})"
+        help=f"Human-readable device name (default: {settings.device_name})",
     )
 
     parser.add_argument(
         "--mgmt-network",
         default=settings.mgmt_network,
-        help=f"Management network for routing (default: {settings.mgmt_network})"
+        help=f"Management network for routing (default: {settings.mgmt_network})",
     )
 
-    parser.add_argument(
-        "-v", "--verbose",
-        action="store_true",
-        help="Enable verbose logging"
-    )
+    parser.add_argument("-v", "--verbose", action="store_true", help="Enable verbose logging")
 
     parser.add_argument(
         "--preserve-wifi",
         action="store_true",
         default=settings.preserve_wifi,
-        help="Preserve WiFi connectivity during USB NIC configuration"
+        help="Preserve WiFi connectivity during USB NIC configuration",
     )
 
     parser.add_argument(
         "--show-dashboard",
         action="store_true",
         default=settings.show_dashboard,
-        help="Display real-time network monitoring dashboard"
+        help="Display real-time network monitoring dashboard",
     )
 
     parser.add_argument(
-        "--fix-vpn-issues",
-        action="store_true",
-        help="Fix network priority and DNS issues caused by VPN connections"
+        "--fix-vpn-issues", action="store_true", help="Fix network priority and DNS issues caused by VPN connections"
     )
 
-    parser.add_argument(
-        "--version",
-        action="version",
-        version="USB NIC Configurator 2.0.0"
-    )
+    parser.add_argument("--version", action="version", version="USB NIC Configurator 2.0.0")
 
     return parser
 
@@ -201,11 +164,7 @@ def show_config(settings: Settings) -> None:
 
         for name, profile in settings.profiles.items():
             default_marker = " [yellow]*[/yellow]" if name == settings.default_profile else ""
-            profiles_table.add_row(
-                f"{name}{default_marker}",
-                profile.device_ip,
-                profile.device_name
-            )
+            profiles_table.add_row(f"{name}{default_marker}", profile.device_ip, profile.device_name)
 
         console.print(profiles_table)
         console.print("[dim]* = default profile[/dim]")
@@ -245,6 +204,7 @@ def main() -> int:
     # Load settings first (before parsing args, so defaults come from config)
     # We need to do a preliminary parse just for --profile
     import sys
+
     profile_arg = None
     if "--profile" in sys.argv:
         try:
@@ -316,15 +276,12 @@ def main() -> int:
             laptop_ip=args.laptop_ip,
             netmask=args.netmask,
             mgmt_network=args.mgmt_network,
-            device_name=args.device_name
+            device_name=args.device_name,
         )
 
         # Create and run configurator
         configurator = USBNICConfigurator(
-            config,
-            dry_run=args.dry_run,
-            preserve_wifi=args.preserve_wifi,
-            show_dashboard=args.show_dashboard
+            config, dry_run=args.dry_run, preserve_wifi=args.preserve_wifi, show_dashboard=args.show_dashboard
         )
         success = configurator.configure()
 
@@ -345,22 +302,21 @@ def handle_vpn_repair() -> int:
     """Handle VPN network repair functionality"""
     console = Console()
     logger = logging.getLogger(__name__)
-    
+
     try:
         # Import here to avoid circular imports
-        from .network_manager import ServiceOrderManager, WiFiMonitor
-        
+        from .network_manager import ServiceOrderManager
+
         console.print("[bold cyan]VPN Network Repair[/bold cyan]")
         console.print("Fixing network priority and DNS issues caused by VPN...\n")
-        
+
         # Initialize managers
         service_manager = ServiceOrderManager()
-        wifi_monitor = WiFiMonitor()
-        
+
         # Create backup
         logger.info("Creating backup of current network settings...")
         service_manager.backup_service_order()
-        
+
         # Fix WiFi priority
         logger.info("Restoring WiFi priority...")
         if service_manager.set_wifi_priority():
@@ -368,13 +324,17 @@ def handle_vpn_repair() -> int:
         else:
             console.print("[red][FAIL] Failed to restore WiFi priority[/red]")
             return 1
-        
+
         # Fix DNS
         logger.info("Fixing DNS configuration...")
         try:
             # Set reliable DNS servers
-            subprocess.run(["networksetup", "-setdnsservers", "Wi-Fi", "8.8.8.8", "8.8.4.4", "1.1.1.1"],
-                         check=True, capture_output=True, timeout=30)
+            subprocess.run(
+                ["networksetup", "-setdnsservers", "Wi-Fi", "8.8.8.8", "8.8.4.4", "1.1.1.1"],
+                check=True,
+                capture_output=True,
+                timeout=30,
+            )
             console.print("[green][OK] DNS servers updated[/green]")
 
             # Flush DNS cache
@@ -385,24 +345,24 @@ def handle_vpn_repair() -> int:
         except subprocess.CalledProcessError as e:
             console.print(f"[red][FAIL] Failed to fix DNS: {e}[/red]")
             return 1
-        
+
         # Wait for network to stabilize
         console.print("[yellow]Waiting for network to stabilize...[/yellow]")
         time.sleep(3)
-        
+
         # Verify connectivity
         logger.info("Verifying network connectivity...")
         try:
             # Test DNS resolution
-            result = subprocess.run(["nslookup", "google.com"], 
-                                  capture_output=True, text=True, timeout=10)
+            result = subprocess.run(["nslookup", "google.com"], capture_output=True, text=True, timeout=10)
             dns_working = result.returncode == 0
-            
+
             # Test internet connectivity
-            result = subprocess.run(["ping", "-c", "1", "-t", "5", "8.8.8.8"], 
-                                  capture_output=True, text=True, timeout=10)
+            result = subprocess.run(
+                ["ping", "-c", "1", "-t", "5", "8.8.8.8"], capture_output=True, text=True, timeout=10
+            )
             internet_working = result.returncode == 0
-            
+
             if dns_working and internet_working:
                 console.print("[bold green][OK] Network repair completed successfully![/bold green]")
                 console.print("\n[cyan]What was fixed:[/cyan]")
@@ -416,7 +376,7 @@ def handle_vpn_repair() -> int:
                 console.print(f"DNS: {'Working' if dns_working else 'Broken'}")
                 console.print(f"Internet: {'Working' if internet_working else 'Broken'}")
                 return 1
-                
+
         except subprocess.TimeoutExpired:
             console.print("[red][FAIL] Network verification timed out[/red]")
             return 1

--- a/src/darwin_mgmt_nic/config.py
+++ b/src/darwin_mgmt_nic/config.py
@@ -5,7 +5,6 @@ Python 3.14+ with modern type system
 
 import ipaddress
 from dataclasses import dataclass
-from typing import Optional
 from enum import Enum
 
 # Python 3.14 type aliases
@@ -16,6 +15,7 @@ type MACAddress = str
 
 class OSType(Enum):
     """Supported operating systems"""
+
     MACOS = "darwin"
     LINUX = "linux"
     WINDOWS = "win32"
@@ -36,6 +36,7 @@ class NetworkConfig:
     Raises:
         ValueError: If IP addresses or networks are invalid
     """
+
     device_ip: IPAddress
     laptop_ip: IPAddress
     netmask: str
@@ -78,15 +79,16 @@ class NetworkInterface:
         mac_address: MAC address
         vendor: USB vendor if detected
     """
+
     name: InterfaceName
     hardware_port: str
     is_usb: bool
     is_wifi: bool = False
     is_active: bool = False
     is_protected: bool = False
-    current_ip: Optional[IPAddress] = None
-    mac_address: Optional[MACAddress] = None
-    vendor: Optional[str] = None
+    current_ip: IPAddress | None = None
+    mac_address: MACAddress | None = None
+    vendor: str | None = None
 
     def __str__(self) -> str:
         """Human-readable interface representation with status icons"""

--- a/src/darwin_mgmt_nic/configurator.py
+++ b/src/darwin_mgmt_nic/configurator.py
@@ -3,8 +3,7 @@ Main configurator orchestrating USB NIC setup with safety checks
 """
 
 import logging
-import ipaddress
-from typing import Optional
+from collections.abc import Sequence
 
 from rich.console import Console
 from rich.prompt import Confirm
@@ -13,8 +12,12 @@ from .config import NetworkConfig, NetworkInterface
 from .detectors import USBNICDetector
 from .factory import USBNICDetectorFactory
 from .network_manager import (
-    ServiceOrderManager, WiFiMonitor, InterfaceScorer, RouteManager,
-    InterferenceAssessor, NetworkDashboard
+    InterfaceScorer,
+    InterferenceAssessor,
+    NetworkDashboard,
+    RouteManager,
+    ServiceOrderManager,
+    WiFiMonitor,
 )
 
 logger = logging.getLogger(__name__)
@@ -42,12 +45,12 @@ class USBNICConfigurator:
         self,
         config: NetworkConfig,
         dry_run: bool = False,
-        detector: Optional[USBNICDetector] = None,
+        detector: USBNICDetector | None = None,
         skip_confirmation: bool = False,
         preserve_wifi: bool = False,
         management_location: bool = False,
         show_dashboard: bool = False,
-        forced_interface: Optional[str] = None
+        forced_interface: str | None = None,
     ):
         """
         Initialize configurator.
@@ -79,7 +82,8 @@ class USBNICConfigurator:
     def display_banner(self) -> None:
         """Display configuration banner with mode and settings"""
         mode = "[DRY-RUN MODE]" if self.dry_run else "[CONFIGURATION MODE]"
-        print(f"""
+        print(
+            f"""
 ╔═══════════════════════════════════════════════════════════════╗
 ║          USB Network Auto-Configuration (SAFE)                ║
 ║          {mode:^55}                     ║
@@ -91,9 +95,10 @@ Device IP:     {self.config.device_ip}
 Laptop IP:     {self.config.laptop_ip}
 Netmask:       {self.config.netmask}
 Mgmt Network:  {self.config.mgmt_network}
-""")
+"""
+        )
 
-    def find_best_usb_interface(self) -> Optional[NetworkInterface]:
+    def find_best_usb_interface(self) -> NetworkInterface | None:
         """
         Find best USB interface for configuration.
 
@@ -125,10 +130,7 @@ Mgmt Network:  {self.config.mgmt_network}
         self._display_interfaces(interfaces)
 
         # Filter for non-protected USB interfaces
-        usb_interfaces = [
-            iface for iface in interfaces
-            if iface.is_usb and not iface.is_protected
-        ]
+        usb_interfaces = [iface for iface in interfaces if iface.is_usb and not iface.is_protected]
 
         if not usb_interfaces:
             logger.error("[FAIL] No USB network interfaces found!")
@@ -138,12 +140,16 @@ Mgmt Network:  {self.config.mgmt_network}
         # Use interface scorer for enhanced selection if WiFi preservation is enabled
         if self.preserve_wifi:
             scored_interfaces = self.interface_scorer.rank_interfaces(interfaces)
-            usb_scored = [score for score in scored_interfaces if score.interface_name in [iface.name for iface in usb_interfaces]]
-            
+            usb_scored = [
+                score for score in scored_interfaces if score.interface_name in [iface.name for iface in usb_interfaces]
+            ]
+
             if usb_scored:
                 best_name = usb_scored[0].interface_name
                 best = next(iface for iface in usb_interfaces if iface.name == best_name)
-                logger.info(f"[OK] Selected best USB interface by score: {best.name} (score: {usb_scored[0].score:.1f})")
+                logger.info(
+                    f"[OK] Selected best USB interface by score: {best.name} (score: {usb_scored[0].score:.1f})"
+                )
                 return best
 
         # Fallback to original logic
@@ -159,7 +165,7 @@ Mgmt Network:  {self.config.mgmt_network}
         logger.warning(f"[!] No active USB interfaces, trying: {best.name}")
         return best
 
-    def _display_interfaces(self, interfaces: list[NetworkInterface]) -> None:
+    def _display_interfaces(self, interfaces: Sequence[NetworkInterface]) -> None:
         """Display detected interfaces in formatted table"""
         print("\n╔═══════════════════════════════════════════════════════════════╗")
         print("║                   Detected Interfaces                         ║")
@@ -186,7 +192,8 @@ Mgmt Network:  {self.config.mgmt_network}
         if self.skip_confirmation:
             return True
 
-        print(f"""
+        print(
+            f"""
 ╔═══════════════════════════════════════════════════════════════╗
 ║                   CONFIGURATION CONFIRMATION                  ║
 ╠═══════════════════════════════════════════════════════════════╣
@@ -200,7 +207,8 @@ Mgmt Network:  {self.config.mgmt_network}
 ║   Netmask:    {self.config.netmask:47} ║
 ║   Route:      {self.config.mgmt_network} via {self.config.device_ip:21} ║
 ╚═══════════════════════════════════════════════════════════════╝
-""")
+"""
+        )
 
         if self.dry_run:
             print("[DRY-RUN MODE] No changes will be made\n")
@@ -226,7 +234,7 @@ Mgmt Network:  {self.config.mgmt_network}
         1. Display banner
         2. Find USB interface
         3. Confirm with user
-        4. Preserve WiFi settings (if enabled)
+        4. Preview intended changes in dry-run mode, or preserve WiFi settings if enabled
         5. Configure IP address
         6. Add static route
         7. Test connectivity
@@ -236,6 +244,23 @@ Mgmt Network:  {self.config.mgmt_network}
             True if configuration succeeded and device is reachable
         """
         self.display_banner()
+
+        # Find USB interface
+        interface = self.find_best_usb_interface()
+        if not interface:
+            return False
+
+        # Confirm before proceeding
+        if not self.confirm_configuration(interface):
+            return False
+
+        if self.dry_run:
+            logger.info("[DRY-RUN] Would configure interface")
+            if self.preserve_wifi:
+                logger.info("[DRY-RUN] Would preserve WiFi priority and service order")
+            logger.info("[DRY-RUN] Would add static route")
+            logger.info("[DRY-RUN] Would test connectivity")
+            return True
 
         # WiFi preservation setup
         if self.preserve_wifi:
@@ -265,40 +290,15 @@ Mgmt Network:  {self.config.mgmt_network}
                 for strategy in self.interference_assessor.suggest_mitigation_strategies():
                     logger.info(f"[i] {strategy}")
 
-
-
-        # Find USB interface
-        interface = self.find_best_usb_interface()
-        if not interface:
-            return False
-
-        # Confirm before proceeding
-        if not self.confirm_configuration(interface):
-            return False
-
-        if self.dry_run:
-            logger.info("[DRY-RUN] Would configure interface")
-            logger.info("[DRY-RUN] Would add static route")
-            logger.info("[DRY-RUN] Would test connectivity")
-            return True
-
         # Configure interface
-        if not self.detector.configure_interface(
-            interface.name,
-            self.config.laptop_ip,
-            self.config.netmask
-        ):
+        if not self.detector.configure_interface(interface.name, self.config.laptop_ip, self.config.netmask):
             return False
 
         # Add management route (preserve default gateway)
         if self.preserve_wifi:
             self.route_manager.preserve_default_gateway()
-        
-        self.route_manager.add_management_route(
-            self.config.mgmt_network,
-            interface.name,
-            self.config.device_ip
-        )
+
+        self.route_manager.add_management_route(self.config.mgmt_network, interface.name, self.config.device_ip)
 
         # Test connectivity
         device_ok = self.detector.test_connectivity(self.config.device_ip)
@@ -321,14 +321,10 @@ Mgmt Network:  {self.config.mgmt_network}
 
         return device_ok
 
-    def _display_results(
-        self,
-        interface: NetworkInterface,
-        device_ok: bool,
-        mgmt_ok: bool
-    ) -> None:
+    def _display_results(self, interface: NetworkInterface, device_ok: bool, mgmt_ok: bool) -> None:
         """Display final configuration results"""
-        print(f"""
+        print(
+            f"""
 ╔═══════════════════════════════════════════════════════════════╗
 ║                  Configuration Complete                       ║
 ╠═══════════════════════════════════════════════════════════════╣
@@ -338,20 +334,25 @@ Mgmt Network:  {self.config.mgmt_network}
 ║ Device:       {'[OK] REACHABLE' if device_ok else '[--] NOT REACHABLE':47} ║
 ║ Mgmt Network: {'[OK] REACHABLE' if mgmt_ok else '[!!] NOT REACHABLE':47} ║
 ╚═══════════════════════════════════════════════════════════════╝
-""")
+"""
+        )
 
         if device_ok:
-            print("""
+            print(
+                """
 Next Steps:
 1. ansible all -m ping
 2. ansible-playbook site.yml --tags wan,uplinks,internet
 3. ansible-playbook site.yml --tags validation
-""")
+"""
+            )
         else:
-            print(f"""
+            print(
+                f"""
 Troubleshooting:
 1. Check USB cable connection to {self.config.device_name}
 2. Verify link lights on both ends
 3. Ensure device is powered on
 4. Try manual ping: ping {self.config.device_ip}
-""")
+"""
+            )

--- a/src/darwin_mgmt_nic/detectors.py
+++ b/src/darwin_mgmt_nic/detectors.py
@@ -3,10 +3,10 @@ Abstract base classes and protocols for USB NIC detection
 """
 
 from abc import ABC, abstractmethod
-from typing import Protocol, Sequence
-from collections.abc import Sequence as ABCSequence
+from collections.abc import Sequence
+from typing import Protocol
 
-from .config import NetworkInterface, InterfaceName, IPAddress
+from .config import InterfaceName, IPAddress, NetworkInterface
 
 
 class NetworkDetector(Protocol):
@@ -34,22 +34,26 @@ class USBNICDetector(ABC):
 
     # Protected interfaces that must NEVER be modified
     # This is a class attribute shared across all instances
-    PROTECTED_INTERFACES: frozenset[InterfaceName] = frozenset({
-        # macOS
-        "en0",    # Primary WiFi
-        "en1",    # Primary Ethernet
-        "lo0",    # Loopback
-        "awdl0",  # Apple Wireless Direct Link
-        "llw0",   # Low Latency WLAN
-        "utun0", "utun1", "utun2",  # VPN tunnels
-        # Linux
-        "eth0",   # Primary Ethernet
-        "wlan0",  # Primary WiFi
-        "lo",     # Loopback
-        # Windows
-        "Ethernet",
-        "Wi-Fi",
-    })
+    PROTECTED_INTERFACES: frozenset[InterfaceName] = frozenset(
+        {
+            # macOS
+            "en0",  # Primary WiFi
+            "en1",  # Primary Ethernet
+            "lo0",  # Loopback
+            "awdl0",  # Apple Wireless Direct Link
+            "llw0",  # Low Latency WLAN
+            "utun0",
+            "utun1",
+            "utun2",  # VPN tunnels
+            # Linux
+            "eth0",  # Primary Ethernet
+            "wlan0",  # Primary WiFi
+            "lo",  # Loopback
+            # Windows
+            "Ethernet",
+            "Wi-Fi",
+        }
+    )
 
     @abstractmethod
     def detect_interfaces(self) -> Sequence[NetworkInterface]:
@@ -76,12 +80,7 @@ class USBNICDetector(ABC):
         ...
 
     @abstractmethod
-    def configure_interface(
-        self,
-        interface: InterfaceName,
-        ip: IPAddress,
-        netmask: str
-    ) -> bool:
+    def configure_interface(self, interface: InterfaceName, ip: IPAddress, netmask: str) -> bool:
         """
         Configure IP address on interface.
 
@@ -114,12 +113,7 @@ class USBNICDetector(ABC):
         ...
 
     @abstractmethod
-    def test_connectivity(
-        self,
-        target_ip: IPAddress,
-        count: int = 3,
-        timeout: int = 2
-    ) -> bool:
+    def test_connectivity(self, target_ip: IPAddress, count: int = 3, timeout: int = 2) -> bool:
         """
         Test ICMP connectivity to target.
 

--- a/src/darwin_mgmt_nic/factory.py
+++ b/src/darwin_mgmt_nic/factory.py
@@ -2,14 +2,13 @@
 Factory pattern for creating platform-specific USB NIC detectors
 """
 
-import platform
 import logging
-from typing import Optional
+import platform
 
 from .config import OSType
 from .detectors import USBNICDetector
-from .macos import MacOSUSBNICDetector
 from .linux import LinuxUSBNICDetector
+from .macos import MacOSUSBNICDetector
 
 logger = logging.getLogger(__name__)
 
@@ -27,7 +26,7 @@ class USBNICDetectorFactory:
     """
 
     @staticmethod
-    def create(os_type: Optional[OSType] = None, tui_mode: bool = False) -> USBNICDetector:
+    def create(os_type: OSType | None = None, tui_mode: bool = False) -> USBNICDetector:
         """
         Create appropriate detector for specified or current platform.
 
@@ -61,10 +60,7 @@ class USBNICDetectorFactory:
                 return LinuxUSBNICDetector()
 
             case OSType.WINDOWS:
-                raise NotImplementedError(
-                    "Windows support not yet implemented. "
-                    "Contributions welcome!"
-                )
+                raise NotImplementedError("Windows support not yet implemented. " "Contributions welcome!")
 
             case _:
                 raise NotImplementedError(f"OS type {os_type} not supported")
@@ -89,13 +85,10 @@ class USBNICDetectorFactory:
         elif system in ("win32", "windows"):
             return OSType.WINDOWS
         else:
-            raise NotImplementedError(
-                f"Platform '{system}' not supported. "
-                f"Supported platforms: macOS, Linux"
-            )
+            raise NotImplementedError(f"Platform '{system}' not supported. " f"Supported platforms: macOS, Linux")
 
     @staticmethod
-    def is_supported(os_type: Optional[OSType] = None) -> bool:
+    def is_supported(os_type: OSType | None = None) -> bool:
         """
         Check if platform is supported.
 

--- a/src/darwin_mgmt_nic/guided_setup.py
+++ b/src/darwin_mgmt_nic/guided_setup.py
@@ -12,36 +12,41 @@ This module provides an interactive, step-by-step setup wizard that:
 Uses a terminal-filling TUI that updates in place (no scrolling).
 """
 
+import json
+import logging
 import sys
 import time
-import logging
-import json
-from pathlib import Path
-from typing import Set, Optional
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from enum import IntEnum
+from pathlib import Path
 
-from rich.console import Console, Group
+from rich import box
+from rich.console import Console
 from rich.panel import Panel
-from rich.prompt import Prompt, Confirm
+from rich.prompt import Confirm, Prompt
 from rich.table import Table
 from rich.text import Text
-from rich import box
 
-from .config import NetworkConfig
+from .config import NetworkConfig, NetworkInterface
 from .configurator import USBNICConfigurator
 from .factory import USBNICDetectorFactory
-from .detectors import NetworkInterface
 from .network_manager import (
-    ServiceOrderManager, WiFiMonitor, InterfaceScorer, RouteManager,
-    InterferenceAssessor, NetworkDashboard
+    InterfaceScorer,
+    InterferenceAssessor,
+    NetworkDashboard,
+    RouteManager,
+    ServiceOrderManager,
+    WiFiMonitor,
+    WiFiStatus,
 )
+from .settings import load_settings
 from .tui import TUIApp, build_content
-from .settings import load_settings, Settings
 
 
 class SetupStep(IntEnum):
     """Setup workflow steps"""
+
     INITIAL = 0
     BASELINE_COMPLETE = 1
     USB_DETECTED = 2
@@ -66,7 +71,7 @@ class SetupStep(IntEnum):
         }
         return names.get(self, str(self.name))
 
-    def can_transition_to(self, target: 'SetupStep') -> bool:
+    def can_transition_to(self, target: SetupStep) -> bool:
         """Check if transition to target step is valid"""
         # Can always go back to INITIAL (reset)
         if target == SetupStep.INITIAL:
@@ -83,10 +88,11 @@ class SetupStep(IntEnum):
 @dataclass
 class SetupState:
     """Track setup progress state"""
+
     current_step: int = 0
-    baseline_interfaces: Set[str] = field(default_factory=set)
-    detected_usb_nic: Optional[str] = None
-    config: Optional[NetworkConfig] = None
+    baseline_interfaces: set[str] = field(default_factory=set)
+    detected_usb_nic: str | None = None
+    config: NetworkConfig | None = None
     configured: bool = False
     verified: bool = False
     timestamp: float = 0.0
@@ -97,13 +103,17 @@ class SetupState:
             "current_step": self.current_step,
             "baseline_interfaces": list(self.baseline_interfaces),
             "detected_usb_nic": self.detected_usb_nic,
-            "config": None if self.config is None else {
-                "device_ip": self.config.device_ip,
-                "laptop_ip": self.config.laptop_ip,
-                "netmask": self.config.netmask,
-                "mgmt_network": self.config.mgmt_network,
-                "device_name": self.config.device_name,
-            },
+            "config": (
+                None
+                if self.config is None
+                else {
+                    "device_ip": self.config.device_ip,
+                    "laptop_ip": self.config.laptop_ip,
+                    "netmask": self.config.netmask,
+                    "mgmt_network": self.config.mgmt_network,
+                    "device_name": self.config.device_name,
+                }
+            ),
             "configured": self.configured,
             "verified": self.verified,
             "timestamp": self.timestamp,
@@ -111,7 +121,7 @@ class SetupState:
         return json.dumps(state_dict, indent=2)
 
     @classmethod
-    def from_json(cls, json_str: str) -> 'SetupState':
+    def from_json(cls, json_str: str) -> SetupState:
         """Deserialize state from JSON string"""
         data = json.loads(json_str)
 
@@ -143,13 +153,13 @@ class GuidedSetup:
     # State file location in /tmp (auto-cleaned on reboot)
     STATE_FILE = Path("/tmp/darwin-nic-setup-state.json")
 
-    def __init__(self, console: Optional[Console] = None):
+    def __init__(self, console: Console | None = None):
         self.console = console or Console()
         self.logger = logging.getLogger(__name__)
         self.state = SetupState()
 
         # TUI app (set during run())
-        self.tui: Optional[TUIApp] = None
+        self.tui: TUIApp | None = None
 
         # Load settings from config files
         self.settings = load_settings()
@@ -180,7 +190,7 @@ class GuidedSetup:
             self.logger.error(f"Failed to save state: {e}")
             return False
 
-    def load_state(self) -> Optional[SetupState]:
+    def load_state(self) -> SetupState | None:
         """
         Load state from disk if it exists.
 
@@ -224,8 +234,9 @@ class GuidedSetup:
         Returns:
             True if resuming from previous state, False for fresh start
         """
-        from rich.prompt import Confirm
         from datetime import datetime
+
+        from rich.prompt import Confirm
 
         previous_state = self.load_state()
         if previous_state is None:
@@ -289,8 +300,10 @@ class GuidedSetup:
             content = build_content(
                 Text("Rollback Instructions", style="bold yellow"),
                 Text(""),
-                *[Text(line, style="cyan" if line.startswith("  sudo") or line.startswith("  ./") else "white")
-                  for line in lines],
+                *[
+                    Text(line, style="cyan" if line.startswith("  sudo") or line.startswith("  ./") else "white")
+                    for line in lines
+                ],
             )
             self.tui.update_body(content)
             self.tui.update_status("Configuration failed - see rollback instructions")
@@ -340,9 +353,7 @@ class GuidedSetup:
         if self.state.detected_usb_nic and self.state.config:
             try:
                 subprocess.run(
-                    ["sudo", "-n", "ifconfig", self.state.detected_usb_nic, "down"],
-                    capture_output=True,
-                    timeout=10
+                    ["sudo", "-n", "ifconfig", self.state.detected_usb_nic, "down"], capture_output=True, timeout=10
                 )
                 results.append(("[OK]", f"Interface {self.state.detected_usb_nic} disabled"))
             except Exception as e:
@@ -355,7 +366,7 @@ class GuidedSetup:
                 subprocess.run(
                     ["sudo", "-n", "route", "delete", "-net", self.state.config.mgmt_network],
                     capture_output=True,
-                    timeout=10
+                    timeout=10,
                 )
                 results.append(("[OK]", "Management route removed"))
             except Exception as e:
@@ -395,11 +406,7 @@ class GuidedSetup:
         return success
 
     def run_step_with_retry(
-        self,
-        step_func,
-        step_name: str,
-        max_retries: int = 2,
-        allow_skip: bool = False
+        self, step_func: Callable[[], bool], step_name: str, max_retries: int = 2, allow_skip: bool = False
     ) -> bool:
         """
         Run a setup step with retry capability.
@@ -443,10 +450,7 @@ class GuidedSetup:
                         return False
                 else:
                     if self.tui:
-                        self.tui.show_error(
-                            f"{step_name} failed",
-                            f"Failed after {max_retries + 1} attempts"
-                        )
+                        self.tui.show_error(f"{step_name} failed", f"Failed after {max_retries + 1} attempts")
                     else:
                         self.print_error(f"{step_name} failed after {max_retries + 1} attempts")
                     return False
@@ -479,12 +483,7 @@ class GuidedSetup:
 
         # Check if already authenticated
         try:
-            result = subprocess.run(
-                ["sudo", "-n", "true"],
-                capture_output=True,
-                text=True,
-                timeout=5
-            )
+            result = subprocess.run(["sudo", "-n", "true"], capture_output=True, text=True, timeout=5)
             if result.returncode == 0:
                 return (True, True, "")
         except subprocess.TimeoutExpired:
@@ -492,12 +491,7 @@ class GuidedSetup:
 
         # Check if user can sudo at all
         try:
-            result = subprocess.run(
-                ["sudo", "-n", "-l"],
-                capture_output=True,
-                text=True,
-                timeout=5
-            )
+            result = subprocess.run(["sudo", "-n", "-l"], capture_output=True, text=True, timeout=5)
             stderr = result.stderr.lower() if result.stderr else ""
 
             if "may not run sudo" in stderr:
@@ -511,18 +505,16 @@ class GuidedSetup:
     def _detect_abr(self) -> bool:
         """Check if Admin By Request is installed"""
         import shutil
+
         abr_app = Path("/Applications/Admin By Request.app")
         return shutil.which("adminbyrequest") is not None or abr_app.exists()
 
     def _try_open_abr(self) -> bool:
         """Attempt to open Admin By Request app"""
         import subprocess
+
         try:
-            subprocess.run(
-                ["open", "-a", "Admin By Request"],
-                capture_output=True,
-                timeout=5
-            )
+            subprocess.run(["open", "-a", "Admin By Request"], capture_output=True, timeout=5)
             return True
         except Exception:
             return False
@@ -541,6 +533,7 @@ class GuidedSetup:
             True if sudo authentication successful, False otherwise
         """
         import subprocess
+
         from rich.prompt import Confirm
 
         self.console.print()
@@ -561,11 +554,7 @@ class GuidedSetup:
                 self.console.print()
 
                 try:
-                    result = subprocess.run(
-                        ["sudo", "-v"],
-                        capture_output=False,
-                        timeout=60
-                    )
+                    result = subprocess.run(["sudo", "-v"], capture_output=False, timeout=60)
 
                     if result.returncode == 0:
                         self.print_success("Sudo authentication successful")
@@ -720,7 +709,7 @@ class GuidedSetup:
         """Print an info message"""
         self.console.print(f"[cyan]ℹ[/cyan]  {message}")
 
-    def get_current_interfaces(self) -> Set[str]:
+    def get_current_interfaces(self) -> set[str]:
         """Get current set of network interfaces"""
         try:
             detector = USBNICDetectorFactory.create(tui_mode=True)
@@ -730,7 +719,7 @@ class GuidedSetup:
             self.logger.error(f"Failed to detect interfaces: {e}")
             return set()
 
-    def get_interface_details(self, interface_name: str) -> Optional[NetworkInterface]:
+    def get_interface_details(self, interface_name: str) -> NetworkInterface | None:
         """Get details for a specific interface"""
         try:
             detector = USBNICDetectorFactory.create(tui_mode=True)
@@ -752,8 +741,8 @@ class GuidedSetup:
             content = build_content(
                 Text("Before we begin:", style="bold yellow"),
                 Text(""),
-                Text("  • Ensure your management USB-to-Ethernet adapter is ", style="white") +
-                    Text("DISCONNECTED", style="bold red"),
+                Text("  • Ensure your management USB-to-Ethernet adapter is ", style="white")
+                + Text("DISCONNECTED", style="bold red"),
                 Text("  • Do NOT connect any cables yet", style="white"),
                 Text("  • We need to establish a baseline of existing interfaces", style="white"),
             )
@@ -777,8 +766,10 @@ class GuidedSetup:
                 table.add_row(iface)
 
             content = build_content(
-                Text(f"✓ Baseline established: {len(self.state.baseline_interfaces)} interfaces detected",
-                     style="bold green"),
+                Text(
+                    f"✓ Baseline established: {len(self.state.baseline_interfaces)} interfaces detected",
+                    style="bold green",
+                ),
                 Text(""),
                 table,
             )
@@ -788,7 +779,9 @@ class GuidedSetup:
             self.print_step(1, 7, "Establish Baseline", "Ensure NO management USB NIC is connected")
             self.console.print()
             self.print_warning("Before we begin:")
-            self.console.print("  • Ensure your management USB-to-Ethernet adapter is [bold red]DISCONNECTED[/bold red]")
+            self.console.print(
+                "  • Ensure your management USB-to-Ethernet adapter is [bold red]DISCONNECTED[/bold red]"
+            )
 
             if not Confirm.ask("Is your management USB NIC DISCONNECTED?", default=False):
                 self.print_error("Please disconnect the USB NIC and try again")
@@ -809,10 +802,8 @@ class GuidedSetup:
             content = build_content(
                 Text("Now we'll detect your management USB NIC:", style="bold cyan"),
                 Text(""),
-                Text("  1. ") + Text("Connect", style="bold cyan") +
-                    Text(" your USB-to-Ethernet adapter to your Mac"),
-                Text("  2. ") + Text("Do NOT", style="bold yellow") +
-                    Text(" plug in the ethernet cable yet"),
+                Text("  1. ") + Text("Connect", style="bold cyan") + Text(" your USB-to-Ethernet adapter to your Mac"),
+                Text("  2. ") + Text("Do NOT", style="bold yellow") + Text(" plug in the ethernet cable yet"),
                 Text("  3. Wait for the adapter to be recognized (LED may light up)"),
             )
             self.tui.update_body(content)
@@ -846,14 +837,16 @@ class GuidedSetup:
             else:
                 self.tui.update_status("Detection failed")
                 self.tui.show_error(
-                    "Timeout: No new USB interface detected",
-                    "Try unplugging and replugging the USB adapter"
+                    "Timeout: No new USB interface detected", "Try unplugging and replugging the USB adapter"
                 )
                 return False
 
             self.tui.update_status("USB NIC detected!")
 
             # Show interface details
+            if self.state.detected_usb_nic is None:
+                self.tui.show_error("Setup Error", "No USB NIC has been detected")
+                return False
             iface_details = self.get_interface_details(self.state.detected_usb_nic)
             details_table = Table(title=f"Interface Details: {self.state.detected_usb_nic}", box=box.ROUNDED)
             details_table.add_column("Property", style="cyan")
@@ -867,8 +860,7 @@ class GuidedSetup:
                 details_table.add_row("Name", self.state.detected_usb_nic)
 
             content = build_content(
-                Text(f"✓ USB NIC detected: ", style="bold green") +
-                    Text(self.state.detected_usb_nic, style="bold cyan"),
+                Text("✓ USB NIC detected: ", style="bold green") + Text(self.state.detected_usb_nic, style="bold cyan"),
                 Text(""),
                 details_table,
             )
@@ -884,7 +876,7 @@ class GuidedSetup:
                 self.print_error("Setup cancelled")
                 return False
 
-            for attempt in range(30):
+            for _attempt in range(30):
                 time.sleep(1)
                 current_interfaces = self.get_current_interfaces()
                 new_interfaces = current_interfaces - self.state.baseline_interfaces
@@ -908,11 +900,14 @@ class GuidedSetup:
             content = build_content(
                 Text("Now connect the ethernet cable:", style="bold cyan"),
                 Text(""),
-                Text("  1. Locate the ") + Text("management port", style="bold cyan") +
-                    Text(" on your ") + Text("target network device", style="bold"),
+                Text("  1. Locate the ")
+                + Text("management port", style="bold cyan")
+                + Text(" on your ")
+                + Text("target network device", style="bold"),
                 Text("     (Typically an RJ45 ethernet port)", style="dim"),
-                Text("  2. ") + Text("Connect", style="bold cyan") +
-                    Text(" an ethernet cable from your USB adapter to the device"),
+                Text("  2. ")
+                + Text("Connect", style="bold cyan")
+                + Text(" an ethernet cable from your USB adapter to the device"),
                 Text("  3. Wait for link lights on both ends"),
                 Text(""),
                 Text("Important:", style="bold yellow"),
@@ -931,6 +926,9 @@ class GuidedSetup:
             self.tui.update_status("Verifying physical link...", spinner=True)
             time.sleep(2)  # Give link time to establish
 
+            if self.state.detected_usb_nic is None:
+                self.print_error("No USB NIC has been detected")
+                return False
             iface_details = self.get_interface_details(self.state.detected_usb_nic)
             if iface_details and iface_details.is_active:
                 self.tui.update_status("Link established!")
@@ -963,6 +961,9 @@ class GuidedSetup:
                 return False
 
             time.sleep(2)
+            if self.state.detected_usb_nic is None:
+                self.print_error("No USB NIC has been detected")
+                return False
             iface_details = self.get_interface_details(self.state.detected_usb_nic)
             if iface_details and iface_details.is_active:
                 self.print_success("Physical link established")
@@ -1004,7 +1005,7 @@ class GuidedSetup:
                 laptop_ip=laptop_ip,
                 netmask=netmask,
                 mgmt_network=mgmt_network,
-                device_name=self.settings.device_name
+                device_name=self.settings.device_name,
             )
 
             # Show configuration summary
@@ -1040,7 +1041,7 @@ class GuidedSetup:
                     preserve_wifi=True,
                     management_location=False,
                     show_dashboard=False,
-                    forced_interface=self.state.detected_usb_nic
+                    forced_interface=self.state.detected_usb_nic,
                 )
                 success = configurator.configure()
 
@@ -1077,8 +1078,11 @@ class GuidedSetup:
             mgmt_network = Prompt.ask("  Management network", default=self.settings.mgmt_network, console=self.console)
 
             self.state.config = NetworkConfig(
-                device_ip=device_ip, laptop_ip=laptop_ip, netmask=netmask,
-                mgmt_network=mgmt_network, device_name=self.settings.device_name
+                device_ip=device_ip,
+                laptop_ip=laptop_ip,
+                netmask=netmask,
+                mgmt_network=mgmt_network,
+                device_name=self.settings.device_name,
             )
 
             if not Confirm.ask("Apply this configuration?", default=True):
@@ -1087,9 +1091,13 @@ class GuidedSetup:
 
             try:
                 configurator = USBNICConfigurator(
-                    self.state.config, dry_run=False, skip_confirmation=True,
-                    preserve_wifi=True, management_location=False, show_dashboard=False,
-                    forced_interface=self.state.detected_usb_nic
+                    self.state.config,
+                    dry_run=False,
+                    skip_confirmation=True,
+                    preserve_wifi=True,
+                    management_location=False,
+                    show_dashboard=False,
+                    forced_interface=self.state.detected_usb_nic,
                 )
                 if configurator.configure():
                     self.print_success("Network configuration applied successfully")
@@ -1124,9 +1132,7 @@ class GuidedSetup:
 
             try:
                 result = subprocess.run(
-                    ["ping", "-c", "3", "-t", "2", self.state.config.device_ip],
-                    capture_output=True,
-                    timeout=10
+                    ["ping", "-c", "3", "-t", "2", self.state.config.device_ip], capture_output=True, timeout=10
                 )
 
                 if result.returncode == 0:
@@ -1147,7 +1153,9 @@ class GuidedSetup:
                         Text("Troubleshooting:", style="bold yellow"),
                         Text("  • Verify target device is powered on", style="white"),
                         Text("  • Check cable connections", style="white"),
-                        Text(f"  • Verify target device is configured with {self.state.config.device_ip}", style="white"),
+                        Text(
+                            f"  • Verify target device is configured with {self.state.config.device_ip}", style="white"
+                        ),
                         Text("  • Try accessing via vendor management tool to check configuration", style="white"),
                     )
                     self.tui.update_body(content)
@@ -1169,8 +1177,7 @@ class GuidedSetup:
 
             try:
                 result = subprocess.run(
-                    ["ping", "-c", "3", "-t", "2", self.state.config.device_ip],
-                    capture_output=True, timeout=10
+                    ["ping", "-c", "3", "-t", "2", self.state.config.device_ip], capture_output=True, timeout=10
                 )
 
                 if result.returncode == 0:
@@ -1193,7 +1200,7 @@ class GuidedSetup:
 
             try:
                 # Gather network status info
-                wifi_status = self.wifi_monitor.get_status()
+                wifi_status = self.wifi_monitor.get_wifi_status()
                 interference = self.wifi_monitor.detect_interference()
                 service_order_ok = self.service_order_manager.validate_service_order()
 
@@ -1204,34 +1211,33 @@ class GuidedSetup:
                 ]
 
                 # WiFi status
-                if wifi_status.get("connected"):
-                    items.append(Text(f"  WiFi: ", style="white") +
-                                Text("Connected", style="bold green") +
-                                Text(f" ({wifi_status.get('ssid', 'Unknown')})", style="dim"))
+                if wifi_status and wifi_status.status == WiFiStatus.CONNECTED:
+                    items.append(
+                        Text("  WiFi: ", style="white")
+                        + Text("Connected", style="bold green")
+                        + Text(f" ({wifi_status.ssid or 'Unknown'})", style="dim")
+                    )
                 else:
-                    items.append(Text("  WiFi: ", style="white") +
-                                Text("Disconnected", style="bold yellow"))
+                    items.append(Text("  WiFi: ", style="white") + Text("Disconnected", style="bold yellow"))
 
                 # Interference check
                 if interference:
-                    items.append(Text("  Interference: ", style="white") +
-                                Text("Detected", style="bold yellow"))
+                    items.append(Text("  Interference: ", style="white") + Text("Detected", style="bold yellow"))
                     items.append(Text(""))
                     items.append(Text("  Mitigation suggestions:", style="yellow"))
                     for strategy in self.interference_assessor.suggest_mitigation_strategies()[:3]:
                         items.append(Text(f"    • {strategy}", style="dim"))
                 else:
-                    items.append(Text("  Interference: ", style="white") +
-                                Text("None detected", style="bold green"))
+                    items.append(Text("  Interference: ", style="white") + Text("None detected", style="bold green"))
 
                 # Service order
                 items.append(Text(""))
                 if service_order_ok:
-                    items.append(Text("  Service Order: ", style="white") +
-                                Text("Optimal", style="bold green"))
+                    items.append(Text("  Service Order: ", style="white") + Text("Optimal", style="bold green"))
                 else:
-                    items.append(Text("  Service Order: ", style="white") +
-                                Text("May need adjustment", style="bold yellow"))
+                    items.append(
+                        Text("  Service Order: ", style="white") + Text("May need adjustment", style="bold yellow")
+                    )
 
                 content = build_content(*items)
                 self.tui.update_body(content)
@@ -1262,15 +1268,13 @@ class GuidedSetup:
 
         status_table.add_row(
             "USB NIC Detected",
-            "[bold green]✓[/bold green]" if self.state.detected_usb_nic else "[bold red]✗[/bold red]"
+            "[bold green]✓[/bold green]" if self.state.detected_usb_nic else "[bold red]✗[/bold red]",
         )
         status_table.add_row(
-            "Network Configured",
-            "[bold green]✓[/bold green]" if self.state.configured else "[bold red]✗[/bold red]"
+            "Network Configured", "[bold green]✓[/bold green]" if self.state.configured else "[bold red]✗[/bold red]"
         )
         status_table.add_row(
-            "Target Reachable",
-            "[bold green]✓[/bold green]" if self.state.verified else "[bold yellow]⚠[/bold yellow]"
+            "Target Reachable", "[bold green]✓[/bold green]" if self.state.verified else "[bold yellow]⚠[/bold yellow]"
         )
 
         # Build connection details table
@@ -1290,8 +1294,8 @@ class GuidedSetup:
         next_steps = [
             Text("Next Steps:", style="bold cyan"),
             Text(""),
-            Text(f"  1. Test SSH: ") + Text(f"ssh admin@{device_ip}", style="bold"),
-            Text(f"  2. Test Ansible: ") + Text("ansible target-device -m ping", style="bold"),
+            Text("  1. Test SSH: ") + Text(f"ssh admin@{device_ip}", style="bold"),
+            Text("  2. Test Ansible: ") + Text("ansible target-device -m ping", style="bold"),
             Text("  3. If target device not reachable, check interface configuration"),
             Text("  4. Once target responds, test access to other network devices"),
         ]
@@ -1320,19 +1324,23 @@ class GuidedSetup:
                 self.console.print()
                 self.console.print(conn_table)
             self.console.print()
-            self.console.print(Panel(
-                "\n".join([
-                    "[bold cyan]Next Steps:[/bold cyan]",
-                    "",
-                    f"1. Test SSH: [bold]ssh admin@{device_ip}[/bold]",
-                    "2. Test Ansible: [bold]ansible target-device -m ping[/bold]",
-                    "3. If target device not reachable, check interface configuration",
-                    "4. Once target responds, test access to other network devices",
-                ]),
-                title="What's Next?",
-                border_style="green" if self.state.verified else "yellow",
-                padding=(1, 2)
-            ))
+            self.console.print(
+                Panel(
+                    "\n".join(
+                        [
+                            "[bold cyan]Next Steps:[/bold cyan]",
+                            "",
+                            f"1. Test SSH: [bold]ssh admin@{device_ip}[/bold]",
+                            "2. Test Ansible: [bold]ansible target-device -m ping[/bold]",
+                            "3. If target device not reachable, check interface configuration",
+                            "4. Once target responds, test access to other network devices",
+                        ]
+                    ),
+                    title="What's Next?",
+                    border_style="green" if self.state.verified else "yellow",
+                    padding=(1, 2),
+                )
+            )
 
     def run(self) -> int:
         """Run the guided setup workflow"""
@@ -1343,7 +1351,7 @@ class GuidedSetup:
         self.console.clear()
         self.print_header(
             "USB Management NIC - Guided Setup Wizard",
-            "Interactive step-by-step configuration for out-of-band network access"
+            "Interactive step-by-step configuration for out-of-band network access",
         )
 
         # Check platform support
@@ -1365,7 +1373,8 @@ class GuidedSetup:
 
         try:
             # Check terminal size before entering TUI
-            from .tui import get_terminal_size, MIN_WIDTH, MIN_HEIGHT
+            from .tui import MIN_HEIGHT, MIN_WIDTH, get_terminal_size
+
             width, height = get_terminal_size()
             if width < MIN_WIDTH or height < MIN_HEIGHT:
                 self.print_error(f"Terminal too small ({width}x{height})")
@@ -1388,11 +1397,7 @@ class GuidedSetup:
 
                 # Step 2: Insert USB NIC (with retry - detection can fail)
                 if self.state.current_step < 2:
-                    if not self.run_step_with_retry(
-                        self.step2_insert_usb,
-                        "USB NIC detection",
-                        max_retries=2
-                    ):
+                    if not self.run_step_with_retry(self.step2_insert_usb, "USB NIC detection", max_retries=2):
                         self.save_state()
                         return 1
                     self.state.current_step = 2
@@ -1403,11 +1408,7 @@ class GuidedSetup:
 
                 # Step 3: Connect cable (with retry - link can take time)
                 if self.state.current_step < 3:
-                    if not self.run_step_with_retry(
-                        self.step3_connect_cable,
-                        "Cable connection",
-                        max_retries=1
-                    ):
+                    if not self.run_step_with_retry(self.step3_connect_cable, "Cable connection", max_retries=1):
                         self.save_state()
                         return 1
                     self.state.current_step = 3
@@ -1418,11 +1419,7 @@ class GuidedSetup:
 
                 # Step 4: Configure (with retry - network ops can fail)
                 if self.state.current_step < 4:
-                    if not self.run_step_with_retry(
-                        self.step4_configure,
-                        "Network configuration",
-                        max_retries=1
-                    ):
+                    if not self.run_step_with_retry(self.step4_configure, "Network configuration", max_retries=1):
                         self.save_state()
                         self.suggest_rollback()
                         return 1
@@ -1435,10 +1432,7 @@ class GuidedSetup:
                 # Step 5: Verify (with retry, allow skip - verification is non-fatal)
                 if self.state.current_step < 5:
                     self.run_step_with_retry(
-                        self.step5_verify,
-                        "Connectivity verification",
-                        max_retries=2,
-                        allow_skip=True
+                        self.step5_verify, "Connectivity verification", max_retries=2, allow_skip=True
                     )
                     self.state.current_step = 5
                     self.save_state()
@@ -1502,11 +1496,11 @@ def main() -> int:
 
     logging.basicConfig(
         level=logging.INFO,
-        format='%(asctime)s [%(levelname)s] %(name)s: %(message)s',
-        datefmt='%Y-%m-%d %H:%M:%S',
+        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
         handlers=[
-            logging.FileHandler(log_file, mode='w'),
-        ]
+            logging.FileHandler(log_file, mode="w"),
+        ],
     )
 
     # Suppress some noisy loggers

--- a/src/darwin_mgmt_nic/linux.py
+++ b/src/darwin_mgmt_nic/linux.py
@@ -3,11 +3,11 @@ Linux-specific USB NIC detection and configuration (placeholder)
 """
 
 import logging
-from typing import Sequence
+from collections.abc import Sequence
 from pathlib import Path
 
+from .config import InterfaceName, IPAddress, NetworkInterface
 from .detectors import USBNICDetector
-from .config import NetworkInterface, InterfaceName, IPAddress
 
 logger = logging.getLogger(__name__)
 
@@ -34,16 +34,11 @@ class LinuxUSBNICDetector(USBNICDetector):
         if carrier_file.exists():
             try:
                 return carrier_file.read_text().strip() == "1"
-            except:
+            except Exception:
                 return False
         return False
 
-    def configure_interface(
-        self,
-        interface: InterfaceName,
-        ip: IPAddress,
-        netmask: str
-    ) -> bool:
+    def configure_interface(self, interface: InterfaceName, ip: IPAddress, netmask: str) -> bool:
         """Configure using ip command"""
         logger.warning("Linux support not yet implemented")
         return False
@@ -53,20 +48,16 @@ class LinuxUSBNICDetector(USBNICDetector):
         logger.warning("Linux support not yet implemented")
         return False
 
-    def test_connectivity(
-        self,
-        target_ip: IPAddress,
-        count: int = 3,
-        timeout: int = 2
-    ) -> bool:
+    def test_connectivity(self, target_ip: IPAddress, count: int = 3, timeout: int = 2) -> bool:
         """Test connectivity using ping"""
         import subprocess
+
         try:
             result = subprocess.run(
                 ["ping", "-c", str(count), "-W", str(timeout), target_ip],
                 capture_output=True,
-                timeout=count * timeout + 5
+                timeout=count * timeout + 5,
             )
             return result.returncode == 0
-        except:
+        except Exception:
             return False

--- a/src/darwin_mgmt_nic/macos.py
+++ b/src/darwin_mgmt_nic/macos.py
@@ -2,18 +2,17 @@
 macOS-specific USB NIC detection and configuration
 """
 
-import subprocess
-import re
 import logging
 import os
-import sys
+import re
+import subprocess
+from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import Optional, Sequence
-from rich.console import Console
-from rich.prompt import Prompt
 
+from rich.console import Console
+
+from .config import InterfaceName, IPAddress, NetworkInterface
 from .detectors import USBNICDetector
-from .config import NetworkInterface, InterfaceName, IPAddress
 
 logger = logging.getLogger(__name__)
 console = Console()
@@ -30,7 +29,7 @@ class BastionDiagnostics:
     recent_necp_drop: bool
 
 
-def run_sudo_command(cmd: Sequence[str], timeout: int = 30, check: bool = True) -> subprocess.CompletedProcess:
+def run_sudo_command(cmd: Sequence[str], timeout: int = 30, check: bool = True) -> subprocess.CompletedProcess[str]:
     """Run sudo command with proper password handling"""
     # Check if we're already root
     if os.geteuid() == 0:
@@ -62,11 +61,8 @@ def run_sudo_command(cmd: Sequence[str], timeout: int = 30, check: bool = True) 
 
 
 def run_sudo_command_tui_safe(
-    cmd: Sequence[str],
-    timeout: int = 30,
-    check: bool = True,
-    tui_active: bool = False
-) -> subprocess.CompletedProcess:
+    cmd: Sequence[str], timeout: int = 30, check: bool = True, tui_active: bool = False
+) -> subprocess.CompletedProcess[str]:
     """
     Run sudo command with TUI state management.
 
@@ -97,13 +93,7 @@ def run_sudo_command_tui_safe(
 
     try:
         # Run with output capture for TUI mode (prevents terminal corruption)
-        result = subprocess.run(
-            full_cmd,
-            timeout=timeout,
-            check=False,
-            capture_output=True,
-            text=True
-        )
+        result = subprocess.run(full_cmd, timeout=timeout, check=False, capture_output=True, text=True)
 
         if check and result.returncode != 0:
             # Check if failure was due to sudo auth timeout
@@ -112,12 +102,7 @@ def run_sudo_command_tui_safe(
                     "Sudo authentication expired during TUI operation. "
                     "This is a bug - sudo should have been pre-authenticated."
                 )
-            raise subprocess.CalledProcessError(
-                result.returncode,
-                full_cmd,
-                result.stdout,
-                result.stderr
-            )
+            raise subprocess.CalledProcessError(result.returncode, full_cmd, result.stdout, result.stderr)
 
         return result
 
@@ -146,13 +131,33 @@ class MacOSUSBNICDetector(USBNICDetector):
     """
 
     # USB NIC vendor identifiers (comprehensive list)
-    USB_VENDOR_KEYWORDS: frozenset[str] = frozenset({
-        "usb ethernet", "usb 10/100", "usb gigabit", "usb 2.5g", "usb 5g",
-        "realtek", "asix", "apple usb", "belkin usb", "startech",
-        "plugable", "cable matters", "anker usb", "tp-link usb",
-        "ugreen", "j5create", "sabrent", "iogear", "trendnet usb",
-        "monoprice", "insignia usb", "dell usb", "lenovo usb",
-    })
+    USB_VENDOR_KEYWORDS: frozenset[str] = frozenset(
+        {
+            "usb ethernet",
+            "usb 10/100",
+            "usb gigabit",
+            "usb 2.5g",
+            "usb 5g",
+            "realtek",
+            "asix",
+            "apple usb",
+            "belkin usb",
+            "startech",
+            "plugable",
+            "cable matters",
+            "anker usb",
+            "tp-link usb",
+            "ugreen",
+            "j5create",
+            "sabrent",
+            "iogear",
+            "trendnet usb",
+            "monoprice",
+            "insignia usb",
+            "dell usb",
+            "lenovo usb",
+        }
+    )
 
     # Minimum interface number to consider as USB (heuristic)
     MIN_USB_INTERFACE_NUMBER = 5
@@ -171,7 +176,7 @@ class MacOSUSBNICDetector(USBNICDetector):
         cmd: Sequence[str],
         timeout: int = 30,
         check: bool = True,
-    ) -> subprocess.CompletedProcess:
+    ) -> subprocess.CompletedProcess[str]:
         """
         Run a privileged command using the right sudo contract for the current mode.
 
@@ -198,15 +203,11 @@ class MacOSUSBNICDetector(USBNICDetector):
 
         try:
             result = subprocess.run(
-                ["networksetup", "-listallhardwareports"],
-                capture_output=True,
-                text=True,
-                check=True,
-                timeout=10
+                ["networksetup", "-listallhardwareports"], capture_output=True, text=True, check=True, timeout=10
             )
 
-            current_port: Optional[str] = None
-            current_device: Optional[InterfaceName] = None
+            current_port: str | None = None
+            current_device: InterfaceName | None = None
 
             for line in result.stdout.splitlines():
                 if line.startswith("Hardware Port:"):
@@ -226,12 +227,7 @@ class MacOSUSBNICDetector(USBNICDetector):
             logger.warning(f"networksetup detection failed: {e}")
 
         # Sort: USB + active first, protected last
-        interfaces.sort(key=lambda iface: (
-            not iface.is_usb,
-            not iface.is_active,
-            iface.is_protected,
-            iface.name
-        ))
+        interfaces.sort(key=lambda iface: (not iface.is_usb, not iface.is_active, iface.is_protected, iface.name))
 
         return interfaces
 
@@ -254,7 +250,7 @@ class MacOSUSBNICDetector(USBNICDetector):
             is_protected=is_protected,
             current_ip=current_ip,
             mac_address=mac,
-            vendor=vendor
+            vendor=vendor,
         )
 
     def _is_usb_adapter(self, port_name: str, device_name: InterfaceName) -> bool:
@@ -292,20 +288,20 @@ class MacOSUSBNICDetector(USBNICDetector):
     def _is_wifi_adapter(self, port_name: str, device_name: InterfaceName) -> bool:
         """Determine if interface is a WiFi adapter"""
         port_lower = port_name.lower()
-        
+
         # Check for WiFi keywords in port name
         wifi_keywords = ["wi-fi", "wifi", "airport", "wireless", "802.11"]
         for keyword in wifi_keywords:
             if keyword in port_lower:
                 return True
-        
+
         # Check common WiFi interface names
         if device_name in ["en0", "en1"]:  # Common WiFi interfaces on Mac
             return "wi-fi" in port_lower.lower()
-        
+
         return False
 
-    def _extract_vendor(self, port_name: str) -> Optional[str]:
+    def _extract_vendor(self, port_name: str) -> str | None:
         """Extract vendor name from hardware port string"""
         port_lower = port_name.lower()
 
@@ -329,16 +325,10 @@ class MacOSUSBNICDetector(USBNICDetector):
 
         return None
 
-    def _get_interface_ip(self, interface: InterfaceName) -> Optional[IPAddress]:
+    def _get_interface_ip(self, interface: InterfaceName) -> IPAddress | None:
         """Get current IPv4 address of interface"""
         try:
-            result = subprocess.run(
-                ["ifconfig", interface],
-                capture_output=True,
-                text=True,
-                check=True,
-                timeout=5
-            )
+            result = subprocess.run(["ifconfig", interface], capture_output=True, text=True, check=True, timeout=5)
 
             for line in result.stdout.splitlines():
                 # Look for "inet <ip>" (not inet6)
@@ -352,16 +342,10 @@ class MacOSUSBNICDetector(USBNICDetector):
 
         return None
 
-    def _get_mac_address(self, interface: InterfaceName) -> Optional[str]:
+    def _get_mac_address(self, interface: InterfaceName) -> str | None:
         """Get MAC address of interface"""
         try:
-            result = subprocess.run(
-                ["ifconfig", interface],
-                capture_output=True,
-                text=True,
-                check=True,
-                timeout=5
-            )
+            result = subprocess.run(["ifconfig", interface], capture_output=True, text=True, check=True, timeout=5)
 
             for line in result.stdout.splitlines():
                 if "ether" in line:
@@ -377,13 +361,7 @@ class MacOSUSBNICDetector(USBNICDetector):
     def get_interface_status(self, interface: InterfaceName) -> bool:
         """Check if interface has active carrier/link"""
         try:
-            result = subprocess.run(
-                ["ifconfig", interface],
-                capture_output=True,
-                text=True,
-                check=True,
-                timeout=5
-            )
+            result = subprocess.run(["ifconfig", interface], capture_output=True, text=True, check=True, timeout=5)
 
             for line in result.stdout.splitlines():
                 if "status:" in line.lower():
@@ -418,12 +396,7 @@ class MacOSUSBNICDetector(USBNICDetector):
                 except Exception as e:
                     logger.warning(f"Failed to remove IP from {iface.name}: {e}")
 
-    def configure_interface(
-        self,
-        interface: InterfaceName,
-        ip: IPAddress,
-        netmask: str
-    ) -> bool:
+    def configure_interface(self, interface: InterfaceName, ip: IPAddress, netmask: str) -> bool:
         """Configure IP address on interface using ifconfig"""
         # Validate interface is safe to configure
         self.validate_interface_for_config(interface)
@@ -466,13 +439,7 @@ class MacOSUSBNICDetector(USBNICDetector):
         """Add static route using route command"""
         try:
             # Check if route already exists
-            result = subprocess.run(
-                ["netstat", "-rn"],
-                capture_output=True,
-                text=True,
-                check=True,
-                timeout=10
-            )
+            result = subprocess.run(["netstat", "-rn"], capture_output=True, text=True, check=True, timeout=10)
 
             if network in result.stdout and gateway in result.stdout:
                 logger.info(f"Route to {network} via {gateway} already exists")
@@ -492,12 +459,7 @@ class MacOSUSBNICDetector(USBNICDetector):
             logger.error(f"[FAIL] Failed to add route: {e}")
             return False
 
-    def test_connectivity(
-        self,
-        target_ip: IPAddress,
-        count: int = 3,
-        timeout: int = 2
-    ) -> bool:
+    def test_connectivity(self, target_ip: IPAddress, count: int = 3, timeout: int = 2) -> bool:
         """Test ICMP connectivity to target"""
         try:
             logger.info(f"Testing connectivity to {target_ip}...")
@@ -505,7 +467,7 @@ class MacOSUSBNICDetector(USBNICDetector):
                 ["ping", "-c", str(count), "-W", str(timeout), target_ip],
                 capture_output=True,
                 text=True,
-                timeout=count * timeout + 5
+                timeout=count * timeout + 5,
             )
 
             if result.returncode == 0:
@@ -525,15 +487,9 @@ class MacOSUSBNICDetector(USBNICDetector):
 
         This is intentionally best-effort and should never raise on operator hosts.
         """
-        usb_interfaces_with_ip = [
-            iface.name
-            for iface in self.detect_interfaces()
-            if iface.is_usb and iface.current_ip
-        ]
+        usb_interfaces_with_ip = [iface.name for iface in self.detect_interfaces() if iface.is_usb and iface.current_ip]
         nwi_interfaces = self._get_nwi_interfaces()
-        missing_from_nwi = [
-            interface for interface in usb_interfaces_with_ip if interface not in nwi_interfaces
-        ]
+        missing_from_nwi = [interface for interface in usb_interfaces_with_ip if interface not in nwi_interfaces]
 
         return BastionDiagnostics(
             usb_interfaces_with_ip=usb_interfaces_with_ip,

--- a/src/darwin_mgmt_nic/network_manager.py
+++ b/src/darwin_mgmt_nic/network_manager.py
@@ -7,39 +7,42 @@ the three root causes of WiFi connectivity loss: USB 3.0 interference, network
 service reordering, and hardware constraints.
 """
 
+from __future__ import annotations
+
 import logging
 import subprocess
-import time
 import threading
-from typing import Dict, List, Optional, Tuple, Any, Set
+import time
+from collections.abc import Sequence
 from dataclasses import dataclass
 from enum import Enum
+from typing import Any
 
-from rich.console import Console
-from rich.table import Table
-from rich.panel import Panel
-from rich.live import Live
-from rich.layout import Layout
-from rich.text import Text
 from rich import box
+from rich.console import Console
+from rich.layout import Layout
+from rich.panel import Panel
+from rich.table import Table
 
-from .config import NetworkConfig, NetworkInterface
+from .config import NetworkInterface
 
 
 @dataclass
 class HardwareInfo:
     """Hardware information for MacBook models"""
+
     model: str
     year: int
     model_identifier: str
-    usb_ports: List[Dict[str, Any]]
-    wifi_antenna_locations: List[str]
+    usb_ports: list[dict[str, Any]]
+    wifi_antenna_locations: list[str]
     chassis_type: str  # laptop, desktop, etc.
 
 
 @dataclass
 class PortInfo:
     """USB port information"""
+
     name: str
     location: str  # left, right, back, etc.
     port_type: str  # USB-A, USB-C, Thunderbolt
@@ -50,11 +53,13 @@ class PortInfo:
 @dataclass
 class CableQualityInfo:
     """USB cable quality assessment"""
+
     is_shielded: bool
     has_ferrite_core: bool
     cable_length: float  # meters
     usb_version: str  # 2.0, 3.0, 3.1, etc.
     quality_score: float  # 0-100
+
 
 logger = logging.getLogger(__name__)
 console = Console()
@@ -62,6 +67,7 @@ console = Console()
 
 class WiFiStatus(Enum):
     """WiFi connection status"""
+
     CONNECTED = "connected"
     DISCONNECTED = "disconnected"
     DEGRADED = "degraded"
@@ -71,6 +77,7 @@ class WiFiStatus(Enum):
 @dataclass
 class WiFiMetrics:
     """WiFi connection metrics"""
+
     status: WiFiStatus
     signal_strength: float  # RSSI in dBm
     noise_level: float  # Noise in dBm
@@ -86,6 +93,7 @@ class WiFiMetrics:
 @dataclass
 class InterfaceScore:
     """Interface scoring result"""
+
     interface_name: str
     score: float
     wifi_preference: float
@@ -96,172 +104,156 @@ class InterfaceScore:
 
 class ServiceOrderManager:
     """Manages macOS network service order to preserve WiFi priority"""
-    
+
     def __init__(self, timeout: int = 10):
         self.timeout = timeout
-        self._backup_order: Optional[List[str]] = None
+        self._backup_order: list[str] | None = None
         self.logger = logging.getLogger(f"{__name__}.ServiceOrderManager")
-    
-    def backup_service_order(self) -> List[str]:
+
+    def backup_service_order(self) -> list[str]:
         """Backup current network service order"""
         try:
             result = subprocess.run(
-                ["networksetup", "-listnetworkserviceorder"],
-                capture_output=True,
-                text=True,
-                timeout=self.timeout
+                ["networksetup", "-listnetworkserviceorder"], capture_output=True, text=True, timeout=self.timeout
             )
-            
+
             if result.returncode != 0:
                 raise subprocess.CalledProcessError(result.returncode, result.args, result.stdout, result.stderr)
-            
+
             # Parse service order from output like:
             # (1) USB Management
             # (Hardware Port: USB 10/100/1000 LAN, Device: en7)
             # (2) Wi-Fi
             services = []
-            lines = result.stdout.strip().split('\n')
+            lines = result.stdout.strip().split("\n")
             for line in lines:
                 line = line.strip()
-                if line.startswith('(') and ')' in line:
+                if line.startswith("(") and ")" in line:
                     # Extract service name from lines like "(1) USB Management"
-                    service_name = line.split(')', 1)[1].strip()
-                    if service_name and not service_name.startswith('Hardware Port:'):
+                    service_name = line.split(")", 1)[1].strip()
+                    if service_name and not service_name.startswith("Hardware Port:"):
                         services.append(service_name)
-            
+
             self._backup_order = services.copy()
             self.logger.info(f"Backed up service order: {services}")
             return services
-            
+
         except subprocess.TimeoutExpired:
             self.logger.error("Timeout backing up service order")
             return []
         except Exception as e:
             self.logger.error(f"Failed to backup service order: {e}")
             return []
-    
+
     def restore_service_order(self) -> bool:
         """Restore backed up network service order"""
         if not self._backup_order:
             self.logger.warning("No backup service order available")
             return False
-        
+
         try:
             # Build networksetup command
             cmd = ["networksetup", "-ordernetworkservices"] + self._backup_order
-            
-            result = subprocess.run(
-                cmd,
-                capture_output=True,
-                text=True,
-                timeout=self.timeout
-            )
-            
+
+            result = subprocess.run(cmd, capture_output=True, text=True, timeout=self.timeout)
+
             if result.returncode != 0:
                 raise subprocess.CalledProcessError(result.returncode, cmd, result.stdout, result.stderr)
-            
+
             self.logger.info(f"Restored service order: {self._backup_order}")
             return True
-            
+
         except subprocess.TimeoutExpired:
             self.logger.error("Timeout restoring service order")
             return False
         except Exception as e:
             self.logger.error(f"Failed to restore service order: {e}")
             return False
-    
-    def set_wifi_priority(self, wifi_service: Optional[str] = None) -> bool:
+
+    def set_wifi_priority(self, wifi_service: str | None = None) -> bool:
         """Set WiFi service to highest priority in service order"""
         try:
             # Get current service order
             current_order = self._get_current_service_order()
-            
+
             # Find WiFi service if not specified
             if not wifi_service:
                 wifi_service = self._find_wifi_service(current_order)
-            
+
             if not wifi_service:
                 self.logger.error("WiFi service not found")
                 return False
-            
+
             # Move WiFi service to top
             new_order = [wifi_service] + [svc for svc in current_order if svc != wifi_service]
-            
+
             # Apply new order
             cmd = ["networksetup", "-ordernetworkservices"] + new_order
-            result = subprocess.run(
-                cmd,
-                capture_output=True,
-                text=True,
-                timeout=self.timeout
-            )
-            
+            result = subprocess.run(cmd, capture_output=True, text=True, timeout=self.timeout)
+
             if result.returncode != 0:
                 raise subprocess.CalledProcessError(result.returncode, cmd, result.stdout, result.stderr)
-            
+
             self.logger.info(f"Set WiFi priority: {wifi_service} at top of service order")
             return True
-            
+
         except subprocess.TimeoutExpired:
             self.logger.error("Timeout setting WiFi priority")
             return False
         except Exception as e:
             self.logger.error(f"Failed to set WiFi priority: {e}")
             return False
-    
-    def get_current_service_order(self) -> List[str]:
+
+    def get_current_service_order(self) -> list[str]:
         """Get current network service order"""
         return self._get_current_service_order()
-    
-    def _get_current_service_order(self) -> List[str]:
+
+    def _get_current_service_order(self) -> list[str]:
         """Internal method to get current service order"""
         try:
             result = subprocess.run(
-                ["networksetup", "-listnetworkserviceorder"],
-                capture_output=True,
-                text=True,
-                timeout=self.timeout
+                ["networksetup", "-listnetworkserviceorder"], capture_output=True, text=True, timeout=self.timeout
             )
-            
+
             if result.returncode != 0:
                 raise subprocess.CalledProcessError(result.returncode, result.args, result.stdout, result.stderr)
-            
+
             # Parse service order from output
             services = []
-            lines = result.stdout.strip().split('\n')
+            lines = result.stdout.strip().split("\n")
             for line in lines:
                 line = line.strip()
-                if line.startswith('(') and ')' in line:
+                if line.startswith("(") and ")" in line:
                     # Extract service name from lines like "(1) USB Management"
-                    service_name = line.split(')', 1)[1].strip()
-                    if service_name and not service_name.startswith('Hardware Port:'):
+                    service_name = line.split(")", 1)[1].strip()
+                    if service_name and not service_name.startswith("Hardware Port:"):
                         services.append(service_name)
-            
+
             return services
-            
+
         except Exception as e:
             self.logger.error(f"Failed to get service order: {e}")
             return []
-    
-    def _find_wifi_service(self, services: List[str]) -> Optional[str]:
+
+    def _find_wifi_service(self, services: list[str]) -> str | None:
         """Find WiFi service in service list"""
         wifi_keywords = ["wi-fi", "wifi", "airport", "wireless"]
-        
+
         for service in services:
             service_lower = service.lower()
             if any(keyword in service_lower for keyword in wifi_keywords):
                 return service
-        
+
         return None
-    
+
     def validate_service_order(self) -> bool:
         """Validate service order integrity"""
         try:
             current_order = self._get_current_service_order()
-            
+
             if not current_order:
                 return False
-            
+
             # Check if WiFi is reasonably prioritized (not at bottom)
             wifi_service = self._find_wifi_service(current_order)
             if wifi_service:
@@ -269,27 +261,29 @@ class ServiceOrderManager:
                 # WiFi should not be in last 25% of services
                 max_position = len(current_order) * 0.75
                 if wifi_position > max_position:
-                    self.logger.warning(f"WiFi service {wifi_service} is poorly positioned ({wifi_position}/{len(current_order)})")
+                    self.logger.warning(
+                        f"WiFi service {wifi_service} is poorly positioned ({wifi_position}/{len(current_order)})"
+                    )
                     return False
-            
+
             return True
-            
+
         except Exception as e:
             self.logger.error(f"Failed to validate service order: {e}")
             return False
-    
+
     def prevent_usb_priority_takeover(self) -> bool:
         """Prevent USB NIC from taking priority when plugged in"""
         try:
             # Get current service order
             current_order = self._get_current_service_order()
-            
+
             # Find WiFi service
             wifi_service = self._find_wifi_service(current_order)
             if not wifi_service:
                 self.logger.warning("WiFi service not found - cannot prevent USB takeover")
                 return False
-            
+
             # Find USB services
             usb_services = []
             for service in current_order:
@@ -297,34 +291,28 @@ class ServiceOrderManager:
                 if any(keyword in service_lower for keyword in ["usb", "ethernet", "lan", "10/100", "1000"]):
                     if service != wifi_service:  # Don't treat WiFi as USB
                         usb_services.append(service)
-            
+
             # If WiFi is already at top, no action needed
             if current_order[0] == wifi_service:
                 self.logger.info("WiFi already has highest priority - USB takeover prevented")
                 return True
-            
+
             # Create new order with WiFi at top, USB services at bottom
-            non_usb_non_wifi = [svc for svc in current_order 
-                              if svc != wifi_service and svc not in usb_services]
-            
+            non_usb_non_wifi = [svc for svc in current_order if svc != wifi_service and svc not in usb_services]
+
             new_order = [wifi_service] + non_usb_non_wifi + usb_services
-            
+
             # Apply new order
             cmd = ["networksetup", "-ordernetworkservices"] + new_order
-            result = subprocess.run(
-                cmd,
-                capture_output=True,
-                text=True,
-                timeout=self.timeout
-            )
-            
+            result = subprocess.run(cmd, capture_output=True, text=True, timeout=self.timeout)
+
             if result.returncode != 0:
                 raise subprocess.CalledProcessError(result.returncode, cmd, result.stdout, result.stderr)
-            
+
             self.logger.info(f"Prevented USB takeover - WiFi prioritized: {wifi_service}")
             self.logger.debug(f"New service order: {new_order}")
             return True
-            
+
         except subprocess.TimeoutExpired:
             self.logger.error("Timeout preventing USB priority takeover")
             return False
@@ -335,119 +323,110 @@ class ServiceOrderManager:
 
 class WiFiMonitor:
     """Monitor WiFi status and connectivity using airport command"""
-    
+
     def __init__(self, timeout: int = 10):
         self.timeout = timeout
         self.logger = logging.getLogger(f"{__name__}.WiFiMonitor")
         self._airport_path = self._find_airport_command()
-    
-    def _find_airport_command(self) -> Optional[str]:
+
+    def _find_airport_command(self) -> str | None:
         """Find airport command path"""
         airport_paths = [
             "/System/Library/PrivateFrameworks/Apple80211.framework/Versions/Current/Resources/airport",
-            "/System/Library/PrivateFrameworks/Apple80211.framework/Resources/airport"
+            "/System/Library/PrivateFrameworks/Apple80211.framework/Resources/airport",
         ]
-        
+
         for path in airport_paths:
             if subprocess.run(["test", "-f", path], capture_output=True).returncode == 0:
                 return path
-        
+
         self.logger.error("airport command not found")
         return None
-    
-    def get_wifi_status(self) -> Optional[WiFiMetrics]:
+
+    def get_wifi_status(self) -> WiFiMetrics | None:
         """Get comprehensive WiFi status using airport command"""
         if not self._airport_path:
             return None
-        
+
         try:
             # Get WiFi info
-            result = subprocess.run(
-                [self._airport_path, "-I"],
-                capture_output=True,
-                text=True,
-                timeout=self.timeout
-            )
-            
+            result = subprocess.run([self._airport_path, "-I"], capture_output=True, text=True, timeout=self.timeout)
+
             if result.returncode != 0:
                 self.logger.warning("airport command failed - WiFi may be disconnected")
                 return self._create_disconnected_metrics()
-            
+
             # Parse airport output
             return self._parse_airport_output(result.stdout)
-            
+
         except subprocess.TimeoutExpired:
             self.logger.error("Timeout getting WiFi status")
             return None
         except Exception as e:
             self.logger.error(f"Failed to get WiFi status: {e}")
             return None
-    
+
     def check_connectivity(self, test_host: str = "8.8.8.8", count: int = 3) -> bool:
         """Check internet connectivity through WiFi"""
         try:
-            result = subprocess.run(
-                ["ping", "-c", str(count), "-t", "2", test_host],
-                capture_output=True,
-                timeout=15
-            )
-            
+            result = subprocess.run(["ping", "-c", str(count), "-t", "2", test_host], capture_output=True, timeout=15)
+
             success = result.returncode == 0
             self.logger.info(f"Connectivity check to {test_host}: {'PASS' if success else 'FAIL'}")
             return success
-            
+
         except subprocess.TimeoutExpired:
             self.logger.error(f"Connectivity check timeout to {test_host}")
             return False
         except Exception as e:
             self.logger.error(f"Connectivity check failed: {e}")
             return False
-    
-    def monitor_signal_strength(self, duration: int = 10) -> List[float]:
+
+    def monitor_signal_strength(self, duration: int = 10) -> list[float]:
         """Monitor WiFi signal strength over time"""
         if not self._airport_path:
             return []
-        
+
         signal_readings = []
         start_time = time.time()
-        
+
         while time.time() - start_time < duration:
             metrics = self.get_wifi_status()
             if metrics and metrics.signal_strength:
                 signal_readings.append(metrics.signal_strength)
-            
+
             time.sleep(1)
-        
+
         return signal_readings
-    
+
     def detect_interference(self) -> bool:
         """Detect potential WiFi interference based on signal quality"""
         metrics = self.get_wifi_status()
         if not metrics:
             return False
-        
+
         # Check for interference indicators
         interference_indicators = [
             metrics.snr < 20,  # Low signal-to-noise ratio
             metrics.noise_level > -85,  # High noise level
             metrics.transmit_rate < 10,  # Low transmit rate
-            metrics.status == WiFiStatus.DEGRADED
+            metrics.status == WiFiStatus.DEGRADED,
         ]
-        
+
         interference_score = sum(interference_indicators)
         is_interfered = interference_score >= 2
-        
+
         if is_interfered:
             self.logger.warning(f"WiFi interference detected (score: {interference_score}/4)")
-        
+
         return is_interfered
-    
-    def get_connection_details(self) -> Dict[str, str]:
+
+    def get_connection_details(self) -> dict[str, str]:
         """Get detailed WiFi connection information"""
         metrics = self.get_wifi_status()
         if not metrics:
             return {"status": "disconnected"}
-        
+
         return {
             "status": metrics.status.value,
             "ssid": metrics.ssid,
@@ -457,51 +436,51 @@ class WiFiMonitor:
             "signal_strength": f"{metrics.signal_strength} dBm",
             "noise_level": f"{metrics.noise_level} dBm",
             "snr": f"{metrics.snr} dB",
-            "transmit_rate": f"{metrics.transmit_rate} Mbps"
+            "transmit_rate": f"{metrics.transmit_rate} Mbps",
         }
-    
+
     def _parse_airport_output(self, output: str) -> WiFiMetrics:
         """Parse airport command output into WiFiMetrics"""
-        lines = output.split('\n')
+        lines = output.split("\n")
         data = {}
-        
+
         for line in lines:
-            if ':' in line:
-                key, value = line.split(':', 1)
+            if ":" in line:
+                key, value = line.split(":", 1)
                 data[key.strip()] = value.strip()
-        
+
         # Extract values
-        ssid = data.get('SSID', 'Unknown')
-        bssid = data.get('BSSID', 'Unknown')
-        channel = int(data.get('channel', '0').split(',')[0])
-        
+        ssid = data.get("SSID", "Unknown")
+        bssid = data.get("BSSID", "Unknown")
+        channel = int(data.get("channel", "0").split(",")[0])
+
         # Determine band from channel
         if channel <= 14:
             band = "2.4GHz"
         else:
             band = "5GHz"
-        
+
         # Extract RSSI and noise
         rssi = 0
         noise = 0
-        
-        if 'agrCtlRSSI' in data:
-            rssi = int(data['agrCtlRSSI'])
-        elif 'lastTxRate' in data:  # Fallback for some macOS versions
+
+        if "agrCtlRSSI" in data:
+            rssi = int(data["agrCtlRSSI"])
+        elif "lastTxRate" in data:  # Fallback for some macOS versions
             # Try to extract from other fields
             pass
-        
-        if 'agrCtlNoise' in data:
-            noise = int(data['agrCtlNoise'])
-        
+
+        if "agrCtlNoise" in data:
+            noise = int(data["agrCtlNoise"])
+
         # Calculate SNR
         snr = rssi - noise if noise != 0 else 0
-        
+
         # Extract transmit rate
-        tx_rate = 0
-        if 'lastTxRate' in data:
-            tx_rate = float(data['lastTxRate'])
-        
+        tx_rate = 0.0
+        if "lastTxRate" in data:
+            tx_rate = float(data["lastTxRate"])
+
         # Determine status
         if rssi == 0 and snr == 0:
             status = WiFiStatus.DISCONNECTED
@@ -511,7 +490,7 @@ class WiFiMonitor:
             status = WiFiStatus.INTERFERED
         else:
             status = WiFiStatus.CONNECTED
-        
+
         return WiFiMetrics(
             status=status,
             signal_strength=rssi,
@@ -522,9 +501,9 @@ class WiFiMonitor:
             ssid=ssid,
             bssid=bssid,
             channel=channel,
-            band=band
+            band=band,
         )
-    
+
     def _create_disconnected_metrics(self) -> WiFiMetrics:
         """Create metrics for disconnected state"""
         return WiFiMetrics(
@@ -537,35 +516,35 @@ class WiFiMonitor:
             ssid="Disconnected",
             bssid="",
             channel=0,
-            band="Unknown"
+            band="Unknown",
         )
 
 
 class InterfaceScorer:
     """Score network interfaces with WiFi preference"""
-    
-    def __init__(self, wifi_monitor: WiFiMonitor, interference_assessor: 'InterferenceAssessor'):
+
+    def __init__(self, wifi_monitor: WiFiMonitor, interference_assessor: InterferenceAssessor):
         self.wifi_monitor = wifi_monitor
         self.interference_assessor = interference_assessor
         self.logger = logging.getLogger(f"{__name__}.InterfaceScorer")
-    
+
     def score_interface(self, interface: NetworkInterface) -> float:
         """Score a single interface for selection"""
         wifi_preference = self.assess_wifi_preference(interface)
         interference_risk = self.interference_assessor.assess_usb_interference_risk(interface.name)
         capabilities_score = self._evaluate_capabilities(interface)
         reliability_score = self._evaluate_reliability(interface)
-        
+
         # Calculate final score (0-100)
         final_score = (
-            wifi_preference * 0.4 +  # WiFi gets strong preference
-            (100 - interference_risk) * 0.25 +  # Lower risk is better
-            capabilities_score * 0.2 +  # Interface capabilities
-            reliability_score * 0.15  # Historical reliability
+            wifi_preference * 0.4  # WiFi gets strong preference
+            + (100 - interference_risk) * 0.25  # Lower risk is better
+            + capabilities_score * 0.2  # Interface capabilities
+            + reliability_score * 0.15  # Historical reliability
         )
-        
+
         return min(100, max(0, final_score))
-    
+
     def assess_wifi_preference(self, interface: NetworkInterface) -> float:
         """Assess WiFi preference score for interface"""
         # WiFi interfaces get high preference if they have working internet
@@ -579,63 +558,65 @@ class InterfaceScorer:
                     return 60.0  # Medium preference for WiFi without internet
             else:
                 return 30.0  # Low preference for disconnected WiFi
-        
+
         # Non-WiFi interfaces get lower preference
         elif interface.is_usb:
             return 20.0  # Low preference for USB interfaces
         else:
             return 40.0  # Medium preference for other interfaces
-    
+
     def evaluate_interference_risk(self, interface: str) -> float:
         """Evaluate interference risk for interface"""
         return self.interference_assessor.assess_usb_interference_risk(interface)
-    
-    def rank_interfaces(self, interfaces: List[NetworkInterface]) -> List[InterfaceScore]:
+
+    def rank_interfaces(self, interfaces: Sequence[NetworkInterface]) -> list[InterfaceScore]:
         """Rank interfaces by score"""
         scored_interfaces = []
-        
+
         for interface in interfaces:
             score = self.score_interface(interface)
             wifi_preference = self.assess_wifi_preference(interface)
             interference_risk = self.interference_assessor.assess_usb_interference_risk(interface.name)
             capabilities_score = self._evaluate_capabilities(interface)
             reliability_score = self._evaluate_reliability(interface)
-            
-            scored_interfaces.append(InterfaceScore(
-                interface_name=interface.name,
-                score=score,
-                wifi_preference=wifi_preference,
-                interference_risk=interference_risk,
-                capabilities_score=capabilities_score,
-                reliability_score=reliability_score
-            ))
-        
+
+            scored_interfaces.append(
+                InterfaceScore(
+                    interface_name=interface.name,
+                    score=score,
+                    wifi_preference=wifi_preference,
+                    interference_risk=interference_risk,
+                    capabilities_score=capabilities_score,
+                    reliability_score=reliability_score,
+                )
+            )
+
         # Sort by score (descending)
         scored_interfaces.sort(key=lambda x: x.score, reverse=True)
         return scored_interfaces
-    
+
     def _evaluate_capabilities(self, interface: NetworkInterface) -> float:
         """Evaluate interface capabilities"""
         score = 50.0  # Base score
-        
+
         # Active interface gets bonus
         if interface.is_active:
             score += 20.0
-        
+
         # USB interfaces get penalty for interference risk
         if interface.is_usb:
             score -= 10.0
-        
+
         # WiFi interfaces get bonus for wireless capability
         if interface.is_wifi:
             score += 15.0
-        
+
         # Protected interfaces get bonus (they're important)
         if interface.is_protected:
             score += 10.0
-        
+
         return min(100, max(0, score))
-    
+
     def _evaluate_reliability(self, interface: NetworkInterface) -> float:
         """Evaluate interface reliability"""
         # For now, base reliability on interface type and status
@@ -651,30 +632,25 @@ class InterfaceScorer:
 
 class RouteManager:
     """Smart route management for management networks"""
-    
+
     def __init__(self, timeout: int = 10):
         self.timeout = timeout
         self.logger = logging.getLogger(f"{__name__}.RouteManager")
-    
+
     def add_management_route(self, destination: str, interface: str, gateway: str) -> bool:
         """Add route for management network through specific interface"""
         try:
             # Parse destination network
-            if '/' in destination:
+            if "/" in destination:
                 network = destination
             else:
                 network = f"{destination}/32"
-            
+
             # Add route command
             cmd = ["route", "add", "-net", network, gateway]
-            
-            result = subprocess.run(
-                cmd,
-                capture_output=True,
-                text=True,
-                timeout=self.timeout
-            )
-            
+
+            result = subprocess.run(cmd, capture_output=True, text=True, timeout=self.timeout)
+
             if result.returncode == 0:
                 self.logger.info(f"Added management route: {network} via {gateway} on {interface}")
                 return True
@@ -686,37 +662,32 @@ class RouteManager:
                 else:
                     self.logger.error(f"Failed to add route: {result.stderr}")
                     return False
-                    
+
         except subprocess.TimeoutExpired:
             self.logger.error("Timeout adding management route")
             return False
         except Exception as e:
             self.logger.error(f"Failed to add management route: {e}")
             return False
-    
+
     def preserve_default_gateway(self) -> bool:
         """Ensure default gateway points to WiFi interface"""
         try:
             # Get current routes
-            result = subprocess.run(
-                ["netstat", "-rn"],
-                capture_output=True,
-                text=True,
-                timeout=self.timeout
-            )
-            
+            result = subprocess.run(["netstat", "-rn"], capture_output=True, text=True, timeout=self.timeout)
+
             if result.returncode != 0:
                 raise subprocess.CalledProcessError(result.returncode, result.args, result.stdout, result.stderr)
-            
+
             # Parse routes to find default gateway
             default_route = None
-            for line in result.stdout.split('\n'):
-                if line.startswith('default') or line.startswith('0.0.0.0'):
+            for line in result.stdout.split("\n"):
+                if line.startswith("default") or line.startswith("0.0.0.0"):
                     parts = line.split()
                     if len(parts) >= 2:
                         default_route = parts[1]  # Gateway
                         break
-            
+
             if default_route:
                 self.logger.info(f"Current default gateway: {default_route}")
                 # In a full implementation, we might want to ensure this points to WiFi
@@ -724,419 +695,404 @@ class RouteManager:
             else:
                 self.logger.warning("No default gateway found")
                 return False
-                
+
         except Exception as e:
             self.logger.error(f"Failed to preserve default gateway: {e}")
             return False
-    
-    def create_route_table(self, routes: List[Dict[str, str]]) -> bool:
+
+    def create_route_table(self, routes: list[dict[str, str]]) -> bool:
         """Create multiple routes"""
         success_count = 0
-        
+
         for route in routes:
-            destination = route.get('destination')
-            gateway = route.get('gateway')
-            interface = route.get('interface')
-            
-            if destination and gateway:
+            destination = route.get("destination")
+            gateway = route.get("gateway")
+            interface = route.get("interface")
+
+            if destination and gateway and interface:
                 if self.add_management_route(destination, interface, gateway):
                     success_count += 1
-        
+
         self.logger.info(f"Created {success_count}/{len(routes)} routes successfully")
         return success_count == len(routes)
-    
+
     def validate_routing(self) -> bool:
         """Validate routing configuration"""
         try:
             # Check if we can reach management networks
             # This is a basic validation - in practice, you'd check specific routes
-            result = subprocess.run(
-                ["netstat", "-rn"],
-                capture_output=True,
-                text=True,
-                timeout=self.timeout
-            )
-            
+            result = subprocess.run(["netstat", "-rn"], capture_output=True, text=True, timeout=self.timeout)
+
             return result.returncode == 0
-            
+
         except Exception as e:
             self.logger.error(f"Failed to validate routing: {e}")
             return False
-    
+
     def _verify_route(self, network: str, gateway: str) -> bool:
         """Verify if a specific route exists"""
         try:
-            result = subprocess.run(
-                ["netstat", "-rn"],
-                capture_output=True,
-                text=True,
-                timeout=self.timeout
-            )
-            
+            result = subprocess.run(["netstat", "-rn"], capture_output=True, text=True, timeout=self.timeout)
+
             if result.returncode != 0:
                 return False
-            
+
             # Check if route exists
-            for line in result.stdout.split('\n'):
+            for line in result.stdout.split("\n"):
                 if network in line and gateway in line:
                     return True
-            
+
             return False
-            
+
         except Exception:
             return False
 
 
-
-
-
 class HardwareAnalyzer:
     """Analyze MacBook hardware for optimal USB port selection"""
-    
+
     def __init__(self, timeout: int = 10):
         self.timeout = timeout
         self.logger = logging.getLogger(f"{__name__}.HardwareAnalyzer")
-        self._hardware_cache: Optional[HardwareInfo] = None
-    
-    def detect_macbook_model(self) -> Optional[HardwareInfo]:
+        self._hardware_cache: HardwareInfo | None = None
+
+    def detect_macbook_model(self) -> HardwareInfo | None:
         """Detect MacBook model and hardware configuration"""
         if self._hardware_cache:
             return self._hardware_cache
-        
+
         try:
             # Use system_profiler to get hardware info
             result = subprocess.run(
-                ["system_profiler", "SPHardwareDataType", "-json"],
-                capture_output=True,
-                text=True,
-                timeout=self.timeout
+                ["system_profiler", "SPHardwareDataType", "-json"], capture_output=True, text=True, timeout=self.timeout
             )
-            
+
             if result.returncode != 0:
                 raise subprocess.CalledProcessError(result.returncode, result.args, result.stdout, result.stderr)
-            
+
             import json
+
             hardware_data = json.loads(result.stdout)
-            
+
             # Extract model information
-            model_info = hardware_data.get('SPHardwareDataType', [{}])[0]
-            model_name = model_info.get('machine_model', '')
-            model_identifier = model_info.get('system_serial_number', '')
-            
+            model_info = hardware_data.get("SPHardwareDataType", [{}])[0]
+            model_name = model_info.get("machine_model", "")
+            model_identifier = model_info.get("system_serial_number", "")
+
             # Parse model name and year
             model, year = self._parse_model_name(model_name)
-            
+
             # Get port information
             usb_ports = self._get_usb_ports()
-            
+
             # Determine WiFi antenna locations based on model
             antenna_locations = self._get_wifi_antenna_locations(model_name)
-            
+
             hardware_info = HardwareInfo(
                 model=model,
                 year=year,
                 model_identifier=model_identifier,
                 usb_ports=usb_ports,
                 wifi_antenna_locations=antenna_locations,
-                chassis_type=self._determine_chassis_type(model_name)
+                chassis_type=self._determine_chassis_type(model_name),
             )
-            
+
             self._hardware_cache = hardware_info
             self.logger.info(f"Detected MacBook: {model} ({year})")
             return hardware_info
-            
+
         except subprocess.TimeoutExpired:
             self.logger.error("Timeout detecting MacBook model")
             return None
         except Exception as e:
             self.logger.error(f"Failed to detect MacBook model: {e}")
             return None
-    
-    def analyze_port_layout(self) -> List[PortInfo]:
+
+    def analyze_port_layout(self) -> list[PortInfo]:
         """Analyze USB port layout and proximity to WiFi antennas"""
         hardware = self.detect_macbook_model()
         if not hardware:
             return self._get_generic_port_layout()
-        
+
         port_infos = []
-        
+
         for port in hardware.usb_ports:
             proximity = self._calculate_wifi_proximity(port, hardware.wifi_antenna_locations)
             recommended = self._is_port_recommended_for_management(port, proximity)
-            
+
             port_info = PortInfo(
-                name=port.get('name', ''),
-                location=port.get('location', ''),
-                port_type=port.get('type', ''),
+                name=port.get("name", ""),
+                location=port.get("location", ""),
+                port_type=port.get("type", ""),
                 proximity_to_wifi=proximity,
-                recommended_for_management=recommended
+                recommended_for_management=recommended,
             )
             port_infos.append(port_info)
-        
+
         return port_infos
-    
+
     def assess_antenna_proximity(self, port_name: str) -> float:
         """Assess proximity of specific port to WiFi antennas"""
         port_infos = self.analyze_port_layout()
-        
+
         for port_info in port_infos:
             if port_name in port_info.name.lower() or port_info.name.lower() in port_name:
                 return port_info.proximity_to_wifi
-        
+
         # Default to medium proximity if port not found
         return 5.0
-    
-    def recommend_optimal_setup(self) -> Dict[str, Any]:
+
+    def recommend_optimal_setup(self) -> dict[str, Any]:
         """Recommend optimal setup based on hardware analysis"""
         hardware = self.detect_macbook_model()
         if not hardware:
             return self._get_generic_recommendations()
-        
+
         # Get port recommendations
         port_infos = self.analyze_port_layout()
         recommended_ports = [p for p in port_infos if p.recommended_for_management]
-        
+
         # Get cable recommendations
         cable_recommendations = self._get_cable_recommendations(hardware)
-        
+
         # Get WiFi recommendations
         wifi_recommendations = self._get_wifi_recommendations(hardware)
-        
+
         return {
-            'macbook_model': f"{hardware.model} ({hardware.year})",
-            'recommended_ports': recommended_ports,
-            'avoid_ports': [p for p in port_infos if not p.recommended_for_management],
-            'cable_recommendations': cable_recommendations,
-            'wifi_recommendations': wifi_recommendations,
-            'interference_risk': self._assess_overall_interference_risk(hardware)
+            "macbook_model": f"{hardware.model} ({hardware.year})",
+            "recommended_ports": recommended_ports,
+            "avoid_ports": [p for p in port_infos if not p.recommended_for_management],
+            "cable_recommendations": cable_recommendations,
+            "wifi_recommendations": wifi_recommendations,
+            "interference_risk": self._assess_overall_interference_risk(hardware),
         }
-    
+
     def _parse_model_name(self, model_name: str) -> tuple[str, int]:
         """Parse model name and year from system profiler output"""
         # Example: "MacBookPro16,1" -> "MacBook Pro", 2020
-        if 'MacBookPro' in model_name:
+        if "MacBookPro" in model_name:
             model = "MacBook Pro"
-        elif 'MacBookAir' in model_name:
+        elif "MacBookAir" in model_name:
             model = "MacBook Air"
-        elif 'MacBook' in model_name:
+        elif "MacBook" in model_name:
             model = "MacBook"
-        elif 'Macmini' in model_name:
+        elif "Macmini" in model_name:
             model = "Mac mini"
-        elif 'iMac' in model_name:
+        elif "iMac" in model_name:
             model = "iMac"
         else:
             model = "Mac"
-        
+
         # Extract year from model identifier or default to recent
         year = 2020  # Default year
-        
+
         # Try to extract from model number (simplified)
         import re
-        year_match = re.search(r'(\d{4})', model_name)
+
+        year_match = re.search(r"(\d{4})", model_name)
         if year_match:
             year = int(year_match.group(1))
-        
+
         return model, year
-    
-    def _get_usb_ports(self) -> List[Dict[str, Any]]:
+
+    def _get_usb_ports(self) -> list[dict[str, Any]]:
         """Get USB port information from system profiler"""
         try:
             result = subprocess.run(
-                ["system_profiler", "SPUSBDataType", "-json"],
-                capture_output=True,
-                text=True,
-                timeout=self.timeout
+                ["system_profiler", "SPUSBDataType", "-json"], capture_output=True, text=True, timeout=self.timeout
             )
-            
+
             if result.returncode != 0:
                 return []
-            
+
             import json
+
             usb_data = json.loads(result.stdout)
-            
-            ports = []
-            self._extract_usb_ports_recursive(usb_data.get('SPUSBDataType', []), ports)
-            
+
+            ports: list[dict[str, Any]] = []
+            self._extract_usb_ports_recursive(usb_data.get("SPUSBDataType", []), ports)
+
             return ports
-            
+
         except Exception as e:
             self.logger.error(f"Failed to get USB ports: {e}")
             return []
-    
-    def _extract_usb_ports_recursive(self, items: List[Dict], ports: List[Dict]) -> None:
+
+    def _extract_usb_ports_recursive(self, items: list[dict[str, Any]], ports: list[dict[str, Any]]) -> None:
         """Recursively extract USB port information"""
         for item in items:
             # Check if this is a USB hub or controller with ports
-            if item.get('_items'):
-                self._extract_usb_ports_recursive(item['_items'], ports)
-            
+            if item.get("_items"):
+                self._extract_usb_ports_recursive(item["_items"], ports)
+
             # Check if this is a USB device that might be a port
-            if 'USB' in item.get('_name', '') or 'Hub' in item.get('_name', ''):
+            if "USB" in item.get("_name", "") or "Hub" in item.get("_name", ""):
                 port_info = {
-                    'name': item.get('_name', ''),
-                    'location': item.get('Location', ''),
-                    'type': item.get('Device_Speed', ''),
-                    'vendor': item.get('Vendor_ID', ''),
-                    'product_id': item.get('Product_ID', '')
+                    "name": item.get("_name", ""),
+                    "location": item.get("Location", ""),
+                    "type": item.get("Device_Speed", ""),
+                    "vendor": item.get("Vendor_ID", ""),
+                    "product_id": item.get("Product_ID", ""),
                 }
                 ports.append(port_info)
-    
-    def _get_wifi_antenna_locations(self, model_name: str) -> List[str]:
+
+    def _get_wifi_antenna_locations(self, model_name: str) -> list[str]:
         """Get WiFi antenna locations based on MacBook model"""
         # Simplified antenna location mapping
-        if 'MacBookPro' in model_name:
-            return ['display_clamshell', 'bottom_case_near_hinge']
-        elif 'MacBookAir' in model_name:
-            return ['display_clamshell', 'keyboard_area']
-        elif 'MacBook' in model_name:
-            return ['display_clamshell', 'bottom_case']
-        elif 'Macmini' in model_name:
-            return ['rear_panel']
-        elif 'iMac' in model_name:
-            return ['display_frame', 'stand']
+        if "MacBookPro" in model_name:
+            return ["display_clamshell", "bottom_case_near_hinge"]
+        elif "MacBookAir" in model_name:
+            return ["display_clamshell", "keyboard_area"]
+        elif "MacBook" in model_name:
+            return ["display_clamshell", "bottom_case"]
+        elif "Macmini" in model_name:
+            return ["rear_panel"]
+        elif "iMac" in model_name:
+            return ["display_frame", "stand"]
         else:
-            return ['unknown']
-    
+            return ["unknown"]
+
     def _determine_chassis_type(self, model_name: str) -> str:
         """Determine chassis type from model name"""
-        if any(model in model_name for model in ['MacBookPro', 'MacBookAir', 'MacBook']):
-            return 'laptop'
-        elif 'Macmini' in model_name:
-            return 'desktop_small'
-        elif 'iMac' in model_name:
-            return 'desktop_all_in_one'
+        if any(model in model_name for model in ["MacBookPro", "MacBookAir", "MacBook"]):
+            return "laptop"
+        elif "Macmini" in model_name:
+            return "desktop_small"
+        elif "iMac" in model_name:
+            return "desktop_all_in_one"
         else:
-            return 'unknown'
-    
-    def _calculate_wifi_proximity(self, port: Dict[str, str], antenna_locations: List[str]) -> float:
+            return "unknown"
+
+    def _calculate_wifi_proximity(self, port: dict[str, str], antenna_locations: list[str]) -> float:
         """Calculate proximity score (0-10, 10 = closest to WiFi antennas)"""
         # Simplified proximity calculation
-        port_location = port.get('location', '').lower()
-        
+        port_location = port.get("location", "").lower()
+
         proximity_score = 5.0  # Default medium proximity
-        
+
         # Adjust based on location keywords
-        if any(location in port_location for location in ['left', 'right']):
+        if any(location in port_location for location in ["left", "right"]):
             proximity_score = 7.0  # Side ports are closer to antennas
-        elif any(location in port_location for location in ['back', 'rear']):
+        elif any(location in port_location for location in ["back", "rear"]):
             proximity_score = 3.0  # Back ports are farther from antennas
-        elif 'front' in port_location:
+        elif "front" in port_location:
             proximity_score = 6.0  # Front ports are moderately close
-        
+
         return proximity_score
-    
-    def _is_port_recommended_for_management(self, port: Dict[str, str], proximity: float) -> bool:
+
+    def _is_port_recommended_for_management(self, port: dict[str, str], proximity: float) -> bool:
         """Determine if port is recommended for management USB NIC"""
         # Avoid ports too close to WiFi antennas
         if proximity > 7.0:
             return False
-        
+
         # Prefer USB-C/Thunderbolt ports (better shielding)
-        port_type = port.get('type', '').lower()
-        if any(usb_type in port_type for usb_type in ['thunderbolt', 'usb-c', 'usb 3.1']):
+        port_type = port.get("type", "").lower()
+        if any(usb_type in port_type for usb_type in ["thunderbolt", "usb-c", "usb 3.1"]):
             return True
-        
+
         # USB 3.0 ports are acceptable if not too close to antennas
-        if 'usb 3.0' in port_type and proximity < 6.0:
+        if "usb 3.0" in port_type and proximity < 6.0:
             return True
-        
+
         # USB 2.0 ports are generally safe
-        if 'usb 2.0' in port_type:
+        if "usb 2.0" in port_type:
             return True
-        
+
         return False
-    
+
     def _assess_overall_interference_risk(self, hardware: HardwareInfo) -> float:
         """Assess overall interference risk for this hardware"""
         base_risk = 30.0  # Base risk for any USB configuration
-        
+
         # Adjust based on chassis type
-        if hardware.chassis_type == 'laptop':
+        if hardware.chassis_type == "laptop":
             base_risk += 20.0  # Laptops have higher interference risk
-        
+
         # Adjust based on year (newer models have better shielding)
         if hardware.year >= 2020:
             base_risk -= 10.0
         elif hardware.year < 2015:
             base_risk += 15.0
-        
+
         return min(100, max(0, base_risk))
-    
-    def _get_generic_port_layout(self) -> List[PortInfo]:
+
+    def _get_generic_port_layout(self) -> list[PortInfo]:
         """Get generic port layout when hardware detection fails"""
         return [
             PortInfo("Generic USB-A", "unknown", "USB-A", 6.0, True),
             PortInfo("Generic USB-C", "unknown", "USB-C", 4.0, True),
         ]
-    
-    def _get_generic_recommendations(self) -> Dict[str, Any]:
+
+    def _get_generic_recommendations(self) -> dict[str, Any]:
         """Get generic recommendations when hardware detection fails"""
         return {
-            'macbook_model': 'Unknown',
-            'recommended_ports': self._get_generic_port_layout(),
-            'avoid_ports': [],
-            'cable_recommendations': ['Use shielded USB 3.0 cables', 'Prefer USB-C over USB-A'],
-            'wifi_recommendations': ['Use 5GHz WiFi when possible', 'Monitor signal quality'],
-            'interference_risk': 50.0
+            "macbook_model": "Unknown",
+            "recommended_ports": self._get_generic_port_layout(),
+            "avoid_ports": [],
+            "cable_recommendations": ["Use shielded USB 3.0 cables", "Prefer USB-C over USB-A"],
+            "wifi_recommendations": ["Use 5GHz WiFi when possible", "Monitor signal quality"],
+            "interference_risk": 50.0,
         }
-    
-    def _get_cable_recommendations(self, hardware: HardwareInfo) -> List[str]:
+
+    def _get_cable_recommendations(self, hardware: HardwareInfo) -> list[str]:
         """Get cable recommendations based on hardware"""
         recommendations = [
             "Use shielded USB 3.0 cables with ferrite cores",
             "Prefer shorter cables (< 2 meters) for better signal",
         ]
-        
+
         if hardware.year >= 2020:
             recommendations.append("USB-C cables provide better interference protection")
-        
-        if hardware.chassis_type == 'laptop':
+
+        if hardware.chassis_type == "laptop":
             recommendations.append("Consider USB extension cable for better positioning")
-        
+
         return recommendations
-    
-    def _get_wifi_recommendations(self, hardware: HardwareInfo) -> List[str]:
+
+    def _get_wifi_recommendations(self, hardware: HardwareInfo) -> list[str]:
         """Get WiFi recommendations based on hardware"""
         recommendations = [
             "Use 5GHz WiFi band to avoid USB 3.0 interference",
             "Monitor WiFi signal quality during USB NIC usage",
         ]
-        
-        if hardware.chassis_type == 'laptop':
+
+        if hardware.chassis_type == "laptop":
             recommendations.append("Position MacBook to maximize distance from USB adapters")
-        
+
         return recommendations
 
 
 class InterferenceAssessor:
     """Assess USB 3.0 interference risk and provide mitigation guidance"""
-    
-    def __init__(self):
+
+    def __init__(self) -> None:
         self.logger = logging.getLogger(f"{__name__}.InterferenceAssessor")
         self.hardware_analyzer = HardwareAnalyzer()
-    
+        self.wifi_monitor = WiFiMonitor()
+
     def assess_usb_interference_risk(self, interface: str) -> float:
         """Assess USB interference risk for interface (0-100, higher = more risk)"""
         risk_score = 0.0
-        
+
         # Check if interface is USB
         if not self._is_usb_interface(interface):
             return 0.0
-        
+
         # Base risk for USB interfaces
         risk_score += 30.0
-        
+
         # USB 3.0 has higher interference risk
         if self._is_usb_3_interface(interface):
             risk_score += 40.0
-        
+
         # Hardware-specific risk assessment
         hardware = self.hardware_analyzer.detect_macbook_model()
         if hardware:
             # Assess port proximity risk
             proximity_risk = self.hardware_analyzer.assess_antenna_proximity(interface)
             risk_score += proximity_risk * 2.0  # Scale proximity to risk
-        
+
         # Check cable quality indicators
         cable_quality = self._assess_cable_quality(interface)
         if not cable_quality.is_shielded:
@@ -1145,47 +1101,49 @@ class InterferenceAssessor:
             risk_score += 15.0
         if cable_quality.cable_length > 2.0:  # Long cables
             risk_score += 10.0
-        
+
         # Environmental factors
         environmental_risk = self._assess_environmental_factors()
         risk_score += environmental_risk
-        
+
         return min(100, max(0, risk_score))
-    
+
     def check_cable_quality_indicators(self, interface: str) -> bool:
         """Check indicators of cable quality"""
         cable_quality = self._assess_cable_quality(interface)
         return cable_quality.quality_score >= 70.0
-    
-    def recommend_port_selection(self) -> List[str]:
+
+    def recommend_port_selection(self) -> list[str]:
         """Recommend optimal USB ports for minimal interference"""
         recommendations = []
         hardware = self.hardware_analyzer.detect_macbook_model()
-        
+
         if hardware:
             port_infos = self.hardware_analyzer.analyze_port_layout()
             recommended_ports = [p for p in port_infos if p.recommended_for_management]
-            
+
             recommendations.append(f"Recommended ports for {hardware.model}:")
             for port in recommended_ports:
                 recommendations.append(f"  • {port.name} ({port.location}) - Low interference risk")
-            
+
             if len(recommended_ports) < len(port_infos):
                 recommendations.append("Avoid these ports:")
                 for port in [p for p in port_infos if not p.recommended_for_management]:
                     recommendations.append(f"  • {port.name} ({port.location}) - High interference risk")
         else:
             # Generic recommendations
-            recommendations.extend([
-                "Use ports furthest from WiFi antennas (typically right side)",
-                "Avoid ports directly next to display hinge area",
-                "If available, use USB-C ports with proper shielding",
-                "Consider using a high-quality, shielded USB extension cable"
-            ])
-        
+            recommendations.extend(
+                [
+                    "Use ports furthest from WiFi antennas (typically right side)",
+                    "Avoid ports directly next to display hinge area",
+                    "If available, use USB-C ports with proper shielding",
+                    "Consider using a high-quality, shielded USB extension cable",
+                ]
+            )
+
         return recommendations
-    
-    def suggest_mitigation_strategies(self) -> List[str]:
+
+    def suggest_mitigation_strategies(self) -> list[str]:
         """Suggest interference mitigation strategies"""
         hardware = self.hardware_analyzer.detect_macbook_model()
         base_strategies = [
@@ -1194,200 +1152,194 @@ class InterferenceAssessor:
             "Move USB adapter away from MacBook using extension cable",
             "Use USB 2.0 ports if available (lower interference)",
             "Position MacBook to maximize distance from USB adapter",
-            "Consider using Thunderbolt dock with proper shielding"
+            "Consider using Thunderbolt dock with proper shielding",
         ]
-        
+
         if hardware:
             # Add hardware-specific strategies
-            if hardware.chassis_type == 'laptop':
-                base_strategies.extend([
-                    f"For {hardware.model}, avoid left-side USB ports when WiFi is active",
-                    "Use USB-C ports on newer models for better shielding",
-                    "Consider elevating MacBook to improve antenna separation"
-                ])
-            
+            if hardware.chassis_type == "laptop":
+                base_strategies.extend(
+                    [
+                        f"For {hardware.model}, avoid left-side USB ports when WiFi is active",
+                        "Use USB-C ports on newer models for better shielding",
+                        "Consider elevating MacBook to improve antenna separation",
+                    ]
+                )
+
             if hardware.year < 2018:
                 base_strategies.append("Older models may benefit more from USB 2.0 adapters")
-        
+
         return base_strategies
-    
+
     def _assess_cable_quality(self, interface: str) -> CableQualityInfo:
         """Assess USB cable quality through driver and system analysis"""
         try:
             # Try to get USB device information
             result = subprocess.run(
-                ["system_profiler", "SPUSBDataType", "-json"],
-                capture_output=True,
-                text=True,
-                timeout=10
+                ["system_profiler", "SPUSBDataType", "-json"], capture_output=True, text=True, timeout=10
             )
-            
+
             if result.returncode == 0:
                 import json
+
                 usb_data = json.loads(result.stdout)
-                device_info = self._find_usb_device_info(usb_data.get('SPUSBDataType', []), interface)
-                
+                device_info = self._find_usb_device_info(usb_data.get("SPUSBDataType", []), interface)
+
                 if device_info:
                     return self._analyze_device_quality(device_info)
-        
+
         except Exception as e:
             self.logger.error(f"Failed to assess cable quality: {e}")
-        
+
         # Return default/unknown quality assessment
         return CableQualityInfo(
-            is_shielded=False,
-            has_ferrite_core=False,
-            cable_length=1.0,
-            usb_version="3.0",
-            quality_score=50.0
+            is_shielded=False, has_ferrite_core=False, cable_length=1.0, usb_version="3.0", quality_score=50.0
         )
-    
-    def _find_usb_device_info(self, items: List[Dict], interface: str) -> Optional[Dict]:
+
+    def _find_usb_device_info(self, items: list[dict[str, Any]], interface: str) -> dict[str, Any] | None:
         """Find USB device information for specific interface"""
         for item in items:
             # Check if this device matches our interface
             if self._device_matches_interface(item, interface):
                 return item
-            
+
             # Recursively search sub-items
-            if item.get('_items'):
-                found = self._find_usb_device_info(item['_items'], interface)
+            if item.get("_items"):
+                found = self._find_usb_device_info(item["_items"], interface)
                 if found:
                     return found
-        
+
         return None
-    
-    def _device_matches_interface(self, device: Dict, interface: str) -> bool:
+
+    def _device_matches_interface(self, device: dict[str, Any], interface: str) -> bool:
         """Check if USB device matches the network interface"""
         # This is a simplified matching - in practice would need more sophisticated logic
-        device_name = device.get('_name', '').lower()
-        interface_lower = interface.lower()
-        
+        device_name = device.get("_name", "").lower()
+
         # Check for common USB Ethernet adapter patterns
-        ethernet_keywords = ['ethernet', 'lan', 'usb', 'realtek', 'asix']
-        
+        ethernet_keywords = ["ethernet", "lan", "usb", "realtek", "asix"]
+
         return any(keyword in device_name for keyword in ethernet_keywords)
-    
-    def _analyze_device_quality(self, device_info: Dict) -> CableQualityInfo:
+
+    def _analyze_device_quality(self, device_info: dict[str, Any]) -> CableQualityInfo:
         """Analyze device information to assess cable quality"""
         # Extract device speed to determine USB version
-        speed = device_info.get('Device_Speed', '')
+        speed = device_info.get("Device_Speed", "")
         usb_version = self._determine_usb_version(speed)
-        
+
         # Determine shielding based on device type and speed
         is_shielded = self._assess_shielding(device_info, usb_version)
-        
+
         # Ferrite core assessment (simplified - would need physical inspection)
         has_ferrite_core = self._assess_ferrite_core(device_info)
-        
+
         # Cable length estimation (simplified)
         cable_length = self._estimate_cable_length(device_info)
-        
+
         # Calculate overall quality score
-        quality_score = self._calculate_quality_score(
-            is_shielded, has_ferrite_core, cable_length, usb_version
-        )
-        
+        quality_score = self._calculate_quality_score(is_shielded, has_ferrite_core, cable_length, usb_version)
+
         return CableQualityInfo(
             is_shielded=is_shielded,
             has_ferrite_core=has_ferrite_core,
             cable_length=cable_length,
             usb_version=usb_version,
-            quality_score=quality_score
+            quality_score=quality_score,
         )
-    
+
     def _determine_usb_version(self, speed: str) -> str:
         """Determine USB version from device speed"""
         speed_lower = speed.lower()
-        
-        if '480' in speed_lower or 'high' in speed_lower:
+
+        if "480" in speed_lower or "high" in speed_lower:
             return "2.0"
-        elif '5000' in speed_lower or '5' in speed_lower:
+        elif "5000" in speed_lower or "5" in speed_lower:
             return "3.0"
-        elif '10000' in speed_lower or '10' in speed_lower:
+        elif "10000" in speed_lower or "10" in speed_lower:
             return "3.1"
         else:
             return "3.0"  # Default assumption
-    
-    def _assess_shielding(self, device_info: Dict, usb_version: str) -> bool:
+
+    def _assess_shielding(self, device_info: dict[str, Any], usb_version: str) -> bool:
         """Assess if device/cable is likely shielded"""
         # USB 3.x devices are more likely to be shielded
         if usb_version.startswith("3."):
             return True
-        
+
         # Check device vendor for quality indicators
-        vendor = device_info.get('Vendor_ID', '').lower()
-        quality_vendors = ['apple', 'belkin', 'startech', 'plugable']
-        
+        vendor = device_info.get("Vendor_ID", "").lower()
+        quality_vendors = ["apple", "belkin", "startech", "plugable"]
+
         return any(v in vendor for v in quality_vendors)
-    
-    def _assess_ferrite_core(self, device_info: Dict) -> bool:
+
+    def _assess_ferrite_core(self, device_info: dict[str, Any]) -> bool:
         """Assess if cable likely has ferrite core"""
         # This is difficult to detect programmatically
         # Base assessment on device quality indicators
-        product_name = device_info.get('_name', '').lower()
-        
+        product_name = device_info.get("_name", "").lower()
+
         # High-quality cables often mention shielding or noise reduction
-        quality_indicators = ['shielded', 'ferrite', 'noise', 'professional']
-        
+        quality_indicators = ["shielded", "ferrite", "noise", "professional"]
+
         return any(indicator in product_name for indicator in quality_indicators)
-    
-    def _estimate_cable_length(self, device_info: Dict) -> float:
+
+    def _estimate_cable_length(self, device_info: dict[str, Any]) -> float:
         """Estimate cable length (simplified heuristic)"""
         # This is very difficult to detect programmatically
         # Use a reasonable default
         return 1.5  # 1.5 meters default
-    
-    def _calculate_quality_score(self, is_shielded: bool, has_ferrite_core: bool, 
-                              cable_length: float, usb_version: str) -> float:
+
+    def _calculate_quality_score(
+        self, is_shielded: bool, has_ferrite_core: bool, cable_length: float, usb_version: str
+    ) -> float:
         """Calculate overall cable quality score"""
         score = 50.0  # Base score
-        
+
         # Shielding bonus
         if is_shielded:
             score += 20.0
-        
+
         # Ferrite core bonus
         if has_ferrite_core:
             score += 15.0
-        
+
         # Length penalty (longer cables have more interference)
         if cable_length > 2.0:
             score -= 10.0
         elif cable_length > 3.0:
             score -= 20.0
-        
+
         # USB version bonus
         if usb_version == "3.1":
             score += 10.0
         elif usb_version == "3.0":
             score += 5.0
-        
+
         return min(100, max(0, score))
-    
+
     def _assess_environmental_factors(self) -> float:
         """Assess environmental interference factors"""
         environmental_risk = 0.0
-        
+
         # Check current WiFi band (2.4GHz is more susceptible)
         try:
-            wifi_metrics = self.hardware_analyzer.wifi_monitor.get_wifi_status()
+            wifi_metrics = self.wifi_monitor.get_wifi_status()
             if wifi_metrics and wifi_metrics.band == "2.4GHz":
                 environmental_risk += 15.0
-        except:
+        except Exception:
             pass
-        
+
         # Check for other potential interference sources
         # This could be expanded with more environmental sensing
         environmental_risk += 5.0  # Base environmental risk
-        
+
         return environmental_risk
-    
+
     def _is_usb_interface(self, interface: str) -> bool:
         """Check if interface is USB"""
         # Simplified check - in practice would use system_profiler
-        return any(usb_keyword in interface.lower() for usb_keyword in ['usb', 'ethernet', 'lan'])
-    
+        return any(usb_keyword in interface.lower() for usb_keyword in ["usb", "ethernet", "lan"])
+
     def _is_usb_3_interface(self, interface: str) -> bool:
         """Check if USB interface is USB 3.0"""
         # Simplified - would need actual hardware detection
@@ -1396,158 +1348,149 @@ class InterferenceAssessor:
 
 class NetworkDashboard:
     """Real-time network monitoring dashboard"""
-    
+
     def __init__(self, wifi_monitor: WiFiMonitor, service_order_manager: ServiceOrderManager):
         self.wifi_monitor = wifi_monitor
         self.service_order_manager = service_order_manager
         self.console = Console()
         self.logger = logging.getLogger(f"{__name__}.NetworkDashboard")
         self._monitoring = False
-        self._monitor_thread: Optional[threading.Thread] = None
-    
+        self._monitor_thread: threading.Thread | None = None
+
     def display_status(self) -> None:
         """Display current network status"""
         layout = self._create_layout()
         self.console.print(layout)
-    
+
     def show_connectivity_metrics(self) -> None:
         """Show detailed connectivity metrics"""
         wifi_metrics = self.wifi_monitor.get_wifi_status()
         if not wifi_metrics:
             self.console.print("[red]WiFi status unavailable[/red]")
             return
-        
+
         # Create metrics table
         table = Table(title="WiFi Connectivity Metrics", box=box.ROUNDED)
         table.add_column("Metric", style="cyan")
         table.add_column("Value", style="green")
         table.add_column("Status", style="yellow")
-        
+
         # Signal strength
         signal_status = self._get_signal_status(wifi_metrics.signal_strength)
         table.add_row("Signal Strength", f"{wifi_metrics.signal_strength} dBm", signal_status)
-        
+
         # Noise level
         noise_status = self._get_noise_status(wifi_metrics.noise_level)
         table.add_row("Noise Level", f"{wifi_metrics.noise_level} dBm", noise_status)
-        
+
         # SNR
         snr_status = self._get_snr_status(wifi_metrics.snr)
         table.add_row("Signal-to-Noise Ratio", f"{wifi_metrics.snr} dB", snr_status)
-        
+
         # Transmit rate
         rate_status = self._get_rate_status(wifi_metrics.transmit_rate)
         table.add_row("Transmit Rate", f"{wifi_metrics.transmit_rate} Mbps", rate_status)
-        
+
         # Connection status
-        table.add_row("Connection Status", wifi_metrics.status.value, 
-                     "[green]Good[/green]" if wifi_metrics.status == WiFiStatus.CONNECTED else "[red]Poor[/red]")
-        
+        table.add_row(
+            "Connection Status",
+            wifi_metrics.status.value,
+            "[green]Good[/green]" if wifi_metrics.status == WiFiStatus.CONNECTED else "[red]Poor[/red]",
+        )
+
         self.console.print(table)
-    
+
     def monitor_interference(self, duration: int = 30) -> None:
         """Monitor for interference over time"""
         self.console.print(f"[cyan]Monitoring WiFi interference for {duration} seconds...[/cyan]")
-        
+
         signal_readings = self.wifi_monitor.monitor_signal_strength(duration)
-        
+
         if not signal_readings:
             self.console.print("[red]No signal readings available[/red]")
             return
-        
+
         # Analyze signal stability
         avg_signal = sum(signal_readings) / len(signal_readings)
         signal_variance = sum((x - avg_signal) ** 2 for x in signal_readings) / len(signal_readings)
         signal_stability = signal_variance < 25  # Threshold for stability
-        
+
         # Display results
         table = Table(title="Interference Analysis", box=box.ROUNDED)
         table.add_column("Metric", style="cyan")
         table.add_column("Value", style="white")
         table.add_column("Assessment", style="yellow")
-        
-        table.add_row("Average Signal", f"{avg_signal:.1f} dBm", 
-                     self._get_signal_status(avg_signal))
-        table.add_row("Signal Stability", f"Variance: {signal_variance:.1f}",
-                     "[green]Stable[/green]" if signal_stability else "[red]Unstable[/red]")
-        table.add_row("Interference Detected", 
-                     "[red]Yes[/red]" if self.wifi_monitor.detect_interference() else "[green]No[/green]",
-                     "Action Required" if self.wifi_monitor.detect_interference() else "Normal")
-        
+
+        table.add_row("Average Signal", f"{avg_signal:.1f} dBm", self._get_signal_status(avg_signal))
+        table.add_row(
+            "Signal Stability",
+            f"Variance: {signal_variance:.1f}",
+            "[green]Stable[/green]" if signal_stability else "[red]Unstable[/red]",
+        )
+        table.add_row(
+            "Interference Detected",
+            "[red]Yes[/red]" if self.wifi_monitor.detect_interference() else "[green]No[/green]",
+            "Action Required" if self.wifi_monitor.detect_interference() else "Normal",
+        )
+
         self.console.print(table)
-    
+
     def update_real_time_status(self) -> None:
         """Update real-time status display"""
         if not self._monitoring:
             return
-        
+
         # This would be used in a live display context
         # For now, just show current status
         self.display_status()
-    
+
     def start_monitoring(self, update_interval: float = 2.0) -> None:
         """Start real-time monitoring in background thread"""
         if self._monitoring:
             return
-        
+
         self._monitoring = True
         self._monitor_thread = threading.Thread(target=self._monitor_loop, args=(update_interval,))
         self._monitor_thread.daemon = True
         self._monitor_thread.start()
-    
+
     def stop_monitoring(self) -> None:
         """Stop real-time monitoring"""
         self._monitoring = False
         if self._monitor_thread:
             self._monitor_thread.join(timeout=5)
-    
+
     def _create_layout(self) -> Layout:
         """Create dashboard layout"""
         layout = Layout()
-        
+
         # Get current data
         wifi_metrics = self.wifi_monitor.get_wifi_status()
         service_order = self.service_order_manager.get_current_service_order()
-        
+
         # Create panels
         wifi_panel = self._create_wifi_panel(wifi_metrics)
         service_panel = self._create_service_panel(service_order)
         status_panel = self._create_status_panel(wifi_metrics)
-        
+
         # Arrange layout
-        layout.split_column(
-            Layout(name="header", size=3),
-            Layout(name="body"),
-            Layout(name="footer", size=3)
-        )
-        
-        layout["header"].update(Panel(
-            "[bold cyan]Network Dashboard[/bold cyan]",
-            box=box.DOUBLE
-        ))
-        
-        layout["body"].split_row(
-            Layout(name="left", ratio=1),
-            Layout(name="right", ratio=1)
-        )
-        
-        layout["left"].split_column(
-            Layout(name="wifi"),
-            Layout(name="services")
-        )
-        
+        layout.split_column(Layout(name="header", size=3), Layout(name="body"), Layout(name="footer", size=3))
+
+        layout["header"].update(Panel("[bold cyan]Network Dashboard[/bold cyan]", box=box.DOUBLE))
+
+        layout["body"].split_row(Layout(name="left", ratio=1), Layout(name="right", ratio=1))
+
+        layout["left"].split_column(Layout(name="wifi"), Layout(name="services"))
+
         layout["right"].update(status_panel)
         layout["left"]["wifi"].update(wifi_panel)
         layout["left"]["services"].update(service_panel)
-        
-        layout["footer"].update(Panel(
-            "[dim]Press Ctrl+C to exit monitoring[/dim]",
-            box=box.SIMPLE
-        ))
-        
+
+        layout["footer"].update(Panel("[dim]Press Ctrl+C to exit monitoring[/dim]", box=box.SIMPLE))
+
         return layout
-    
-    def _create_wifi_panel(self, metrics: Optional[WiFiMetrics]) -> Panel:
+
+    def _create_wifi_panel(self, metrics: WiFiMetrics | None) -> Panel:
         """Create WiFi status panel"""
         if not metrics:
             content = "[red]WiFi status unavailable[/red]"
@@ -1559,10 +1502,10 @@ class NetworkDashboard:
 [bold]SNR:[/bold] {metrics.snr} dB
 [bold]Rate:[/bold] {metrics.transmit_rate} Mbps
 [bold]Channel:[/bold] {metrics.channel} ({metrics.band})"""
-        
+
         return Panel(content, title="WiFi Information", border_style="cyan")
-    
-    def _create_service_panel(self, services: List[str]) -> Panel:
+
+    def _create_service_panel(self, services: list[str]) -> Panel:
         """Create service order panel"""
         if not services:
             content = "[red]Service order unavailable[/red]"
@@ -1570,10 +1513,10 @@ class NetworkDashboard:
             content = "\n".join(f"• {service}" for service in services[:10])
             if len(services) > 10:
                 content += f"\n... and {len(services) - 10} more"
-        
+
         return Panel(content, title="Network Service Order", border_style="magenta")
-    
-    def _create_status_panel(self, metrics: Optional[WiFiMetrics]) -> Panel:
+
+    def _create_status_panel(self, metrics: WiFiMetrics | None) -> Panel:
         """Create overall status panel"""
         if not metrics:
             status_color = "red"
@@ -1587,7 +1530,7 @@ class NetworkDashboard:
         else:
             status_color = "red"
             status_text = "Poor"
-        
+
         content = f"""[bold]Overall Status:[/bold] [{status_color}]{status_text}[/{status_color}]
 
 [bold]Connectivity:[/bold] {'[OK]' if self.wifi_monitor.check_connectivity() else '[--]'}
@@ -1597,9 +1540,9 @@ class NetworkDashboard:
 • Use 5GHz WiFi if available
 • Keep USB adapter away from antennas
 • Use shielded cables for USB 3.0"""
-        
+
         return Panel(content, title="Network Health", border_style="green")
-    
+
     def _monitor_loop(self, update_interval: float) -> None:
         """Background monitoring loop"""
         while self._monitoring:
@@ -1609,7 +1552,7 @@ class NetworkDashboard:
             except Exception as e:
                 self.logger.error(f"Monitoring loop error: {e}")
                 break
-    
+
     def _get_signal_status(self, signal_dbm: float) -> str:
         """Get signal status with color"""
         if signal_dbm >= -50:
@@ -1620,7 +1563,7 @@ class NetworkDashboard:
             return "[yellow]Fair[/yellow]"
         else:
             return "[red]Poor[/red]"
-    
+
     def _get_noise_status(self, noise_dbm: float) -> str:
         """Get noise status with color"""
         if noise_dbm <= -90:
@@ -1631,7 +1574,7 @@ class NetworkDashboard:
             return "[yellow]Moderate[/yellow]"
         else:
             return "[red]High[/red]"
-    
+
     def _get_snr_status(self, snr_db: float) -> str:
         """Get SNR status with color"""
         if snr_db >= 40:
@@ -1642,7 +1585,7 @@ class NetworkDashboard:
             return "[yellow]Fair[/yellow]"
         else:
             return "[red]Poor[/red]"
-    
+
     def _get_rate_status(self, rate_mbps: float) -> str:
         """Get transmit rate status with color"""
         if rate_mbps >= 100:

--- a/src/darwin_mgmt_nic/settings.py
+++ b/src/darwin_mgmt_nic/settings.py
@@ -14,18 +14,12 @@ Profile support allows named configurations for different environments.
 
 from __future__ import annotations
 
-import os
 import logging
-from pathlib import Path
+import os
+import tomllib
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any
-
-# Python 3.11+ has tomllib in stdlib
-try:
-    import tomllib
-except ImportError:
-    import tomli as tomllib  # type: ignore[import-not-found]
-
 
 logger = logging.getLogger(__name__)
 
@@ -74,6 +68,7 @@ def get_config_paths() -> list[Path]:
 @dataclass
 class NetworkProfile:
     """A named network configuration profile."""
+
     device_ip: str
     laptop_ip: str
     netmask: str = "255.255.255.0"
@@ -105,6 +100,7 @@ class Settings:
     Attributes represent the final resolved values after merging
     all config files, environment variables, and CLI arguments.
     """
+
     # Network defaults (RFC 5737 documentation IPs as fallback)
     device_ip: str = "192.0.2.1"
     laptop_ip: str = "192.0.2.100"
@@ -291,7 +287,7 @@ def ensure_config_dir() -> Path:
 
 def get_default_config_content() -> str:
     """Return default config file content as a string."""
-    return '''# Darwin Management NIC Configurator - User Configuration
+    return """# Darwin Management NIC Configurator - User Configuration
 # Place this file at: ~/.config/darwin-nic/config.toml
 # Or use a local override: ./.darwin-nic.toml
 
@@ -328,7 +324,7 @@ description = "Secondary management target"
 # laptop_ip = "10.200.0.100"
 # mgmt_network = "10.200.0.0/24"
 # device_name = "DC Core Switch"
-'''
+"""
 
 
 def init_config(force: bool = False) -> Path | None:

--- a/src/darwin_mgmt_nic/tui.py
+++ b/src/darwin_mgmt_nic/tui.py
@@ -7,29 +7,29 @@ Uses Rich's Layout and Live to create a proper terminal application.
 Uses alternate screen mode (like vim/emacs) - exits cleanly back to shell.
 """
 
-import os
-import sys
-import tty
-import termios
-import signal
-import shutil
 import itertools
-from typing import Optional, Iterator, Tuple
-from rich.console import Console, RenderableType, Group
+import shutil
+import signal
+import sys
+import termios
+import tty
+from collections.abc import Callable, Iterator
+from types import FrameType, TracebackType
+from typing import Any
+
+from rich import box
+from rich.console import Console, Group, RenderableType
 from rich.layout import Layout
 from rich.live import Live
 from rich.panel import Panel
 from rich.text import Text
-from rich.table import Table
-from rich import box
-
 
 # Minimum terminal size requirements
 MIN_WIDTH = 60
 MIN_HEIGHT = 20
 
 
-def get_terminal_size() -> Tuple[int, int]:
+def get_terminal_size() -> tuple[int, int]:
     """Get current terminal size (width, height)."""
     size = shutil.get_terminal_size(fallback=(80, 24))
     return size.columns, size.lines
@@ -48,10 +48,11 @@ def read_single_key() -> str:
         tty.setraw(fd)
         ch = sys.stdin.read(1)
         # Handle escape sequences (arrow keys, etc.)
-        if ch == '\x1b':
+        if ch == "\x1b":
             # Read additional chars for escape sequence
             try:
                 import select
+
                 # Check if more data is available (escape sequence)
                 if select.select([sys.stdin], [], [], 0.1)[0]:
                     ch2 = sys.stdin.read(1)
@@ -59,7 +60,7 @@ def read_single_key() -> str:
                         ch3 = sys.stdin.read(1)
                         return ch + ch2 + ch3
                     return ch + ch2
-            except:
+            except Exception:
                 pass
         return ch
     finally:
@@ -76,7 +77,7 @@ class ProgressIndicator:
 
     STEPS = ["Baseline", "USB", "Cable", "Config", "Verify", "Monitor", "Done"]
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.current = 0
 
     def set_step(self, step: int) -> None:
@@ -118,7 +119,7 @@ class SpinnerState:
 
     FRAMES = ["◐", "◓", "◑", "◒"]
 
-    def __init__(self):
+    def __init__(self) -> None:
         self._cycle: Iterator[str] = itertools.cycle(self.FRAMES)
         self.active = False
         self.message = ""
@@ -224,12 +225,14 @@ class TUILayout:
                 "[dim]Interactive configuration for out-of-band network access[/dim]"
             )
 
-        self.layout["header"].update(Panel(
-            content,
-            box=box.DOUBLE,
-            border_style="cyan",
-            padding=(0, 1),
-        ))
+        self.layout["header"].update(
+            Panel(
+                content,
+                box=box.DOUBLE,
+                border_style="cyan",
+                padding=(0, 1),
+            )
+        )
 
     def _update_progress_region(self) -> None:
         """Update progress region"""
@@ -242,29 +245,35 @@ class TUILayout:
         else:
             content = Group(step_text, Text(""), self.progress.render())
 
-        self.layout["progress"].update(Panel(
-            content,
-            box=box.SIMPLE,
-            border_style="magenta",
-        ))
+        self.layout["progress"].update(
+            Panel(
+                content,
+                box=box.SIMPLE,
+                border_style="magenta",
+            )
+        )
 
     def _update_body_region(self) -> None:
         """Update body region"""
-        self.layout["body"].update(Panel(
-            self._body_content,
-            box=box.ROUNDED,
-            border_style="white",
-            padding=(0, 1),
-        ))
+        self.layout["body"].update(
+            Panel(
+                self._body_content,
+                box=box.ROUNDED,
+                border_style="white",
+                padding=(0, 1),
+            )
+        )
 
     def _update_status_region(self) -> None:
         """Update status region with prominent styling"""
-        self.layout["status"].update(Panel(
-            self.spinner.render(),
-            box=box.HEAVY,
-            border_style="yellow",
-            padding=(0, 1),
-        ))
+        self.layout["status"].update(
+            Panel(
+                self.spinner.render(),
+                box=box.HEAVY,
+                border_style="yellow",
+                padding=(0, 1),
+            )
+        )
 
     def update_step(self, step: int, title: str) -> None:
         """
@@ -312,12 +321,14 @@ class TUILayout:
             Text(""),
             Text(message, style="red"),
         )
-        self.layout["body"].update(Panel(
-            error_content,
-            box=box.HEAVY,
-            border_style="red",
-            padding=(1, 2),
-        ))
+        self.layout["body"].update(
+            Panel(
+                error_content,
+                box=box.HEAVY,
+                border_style="red",
+                padding=(1, 2),
+            )
+        )
 
     def show_success(self, title: str, message: str = "") -> None:
         """
@@ -331,12 +342,14 @@ class TUILayout:
         if message:
             content_parts.extend([Text(""), Text(message, style="green")])
 
-        self.layout["body"].update(Panel(
-            Group(*content_parts),
-            box=box.ROUNDED,
-            border_style="green",
-            padding=(1, 2),
-        ))
+        self.layout["body"].update(
+            Panel(
+                Group(*content_parts),
+                box=box.ROUNDED,
+                border_style="green",
+                padding=(1, 2),
+            )
+        )
 
     def get_layout(self) -> Layout:
         """Get the layout object for Live display"""
@@ -361,7 +374,7 @@ class TUIApp:
                 ...
     """
 
-    def __init__(self, console: Optional[Console] = None):
+    def __init__(self, console: Console | None = None):
         # Configure console for proper terminal detection
         # See: https://rich.readthedocs.io/en/stable/console.html
         if console is None:
@@ -376,11 +389,11 @@ class TUIApp:
             self.console = console
 
         self.tui = TUILayout(self.console)
-        self.live: Optional[Live] = None
+        self.live: Live | None = None
         self._input_buffer = ""
-        self._old_sigwinch = None
+        self._old_sigwinch: Any = None
 
-    def _handle_resize(self, signum, frame) -> None:
+    def _handle_resize(self, signum: int, frame: FrameType | None) -> None:
         """Handle terminal resize signal (SIGWINCH)."""
         # Update console size
         width, height = get_terminal_size()
@@ -390,7 +403,7 @@ class TUIApp:
         # Refresh display
         self._refresh()
 
-    def check_terminal_size(self) -> Tuple[bool, str]:
+    def check_terminal_size(self) -> tuple[bool, str]:
         """
         Check if terminal meets minimum size requirements.
 
@@ -402,7 +415,7 @@ class TUIApp:
             return False, f"Terminal too small ({width}x{height}). Need at least {MIN_WIDTH}x{MIN_HEIGHT}."
         return True, ""
 
-    def __enter__(self) -> 'TUIApp':
+    def __enter__(self) -> TUIApp:
         """Enter TUI context - start Live display in alternate screen"""
         # Check terminal size
         ok, msg = self.check_terminal_size()
@@ -432,7 +445,12 @@ class TUIApp:
         self.live.refresh()
         return self
 
-    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
         """Exit TUI context - return to normal screen"""
         # Restore original signal handler
         if self._old_sigwinch is not None:
@@ -503,20 +521,20 @@ class TUIApp:
                 key = read_single_key()
 
                 # Handle Ctrl+C
-                if key == '\x03':
+                if key == "\x03":
                     raise KeyboardInterrupt()
 
                 # Handle response
-                if key.lower() == 'y':
+                if key.lower() == "y":
                     self.tui.update_status("Yes", spinner=False)
                     return True
-                elif key.lower() == 'n':
+                elif key.lower() == "n":
                     self.tui.update_status("No", spinner=False)
                     return False
-                elif key in ('\r', '\n'):  # Enter = default
+                elif key in ("\r", "\n"):  # Enter = default
                     self.tui.update_status("Yes" if default else "No", spinner=False)
                     return default
-                elif key == 'q':  # q to quit
+                elif key == "q":  # q to quit
                     raise KeyboardInterrupt()
                 # Ignore other keys, keep waiting
             except KeyboardInterrupt:
@@ -543,29 +561,29 @@ class TUIApp:
                 key = read_single_key()
 
                 # Handle Ctrl+C
-                if key == '\x03':
+                if key == "\x03":
                     raise KeyboardInterrupt()
 
                 # Handle Enter (submit)
-                if key in ('\r', '\n'):
+                if key in ("\r", "\n"):
                     result = self._input_buffer
                     self._input_buffer = ""
                     self.tui.update_status(f"Entered: {result}", spinner=False)
                     return result
 
                 # Handle backspace
-                elif key in ('\x7f', '\x08'):  # DEL or BS
+                elif key in ("\x7f", "\x08"):  # DEL or BS
                     if self._input_buffer:
                         self._input_buffer = self._input_buffer[:-1]
                         self._update_prompt_display(message)
 
                 # Handle Ctrl+U (clear line)
-                elif key == '\x15':
+                elif key == "\x15":
                     self._input_buffer = ""
                     self._update_prompt_display(message)
 
                 # Handle Escape (cancel, use default)
-                elif key.startswith('\x1b'):
+                elif key.startswith("\x1b"):
                     self._input_buffer = default
                     self.tui.update_status(f"Using default: {default}", spinner=False)
                     return default
@@ -600,12 +618,12 @@ class TUIApp:
         key = read_single_key()
 
         # Handle Ctrl+C
-        if key == '\x03':
+        if key == "\x03":
             raise KeyboardInterrupt()
 
         return key
 
-    def run_with_spinner(self, message: str, func, *args, **kwargs):
+    def run_with_spinner(self, message: str, func: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
         """
         Run a function while showing a spinner.
 
@@ -625,7 +643,7 @@ class TUIApp:
         return result
 
 
-def build_content(*items) -> Group:
+def build_content(*items: Any) -> Group:
     """
     Build a Group of content items for the body region.
 
@@ -641,7 +659,7 @@ def build_content(*items) -> Group:
         )
         app.update_body(content)
     """
-    renderables = []
+    renderables: list[RenderableType] = []
     for item in items:
         if isinstance(item, str):
             renderables.append(Text(item))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,11 +2,11 @@
 Pytest configuration and shared fixtures
 """
 
-import pytest
 from unittest.mock import MagicMock, patch
 
-from darwin_mgmt_nic.config import NetworkConfig, NetworkInterface, OSType
-from darwin_mgmt_nic.factory import USBNICDetectorFactory
+import pytest
+
+from darwin_mgmt_nic.config import NetworkConfig, NetworkInterface
 
 
 @pytest.fixture
@@ -17,7 +17,7 @@ def sample_network_config() -> NetworkConfig:
         laptop_ip="192.0.2.100",
         netmask="255.255.255.0",
         mgmt_network="198.51.100.0/24",
-        device_name="Test Device"
+        device_name="Test Device",
     )
 
 
@@ -29,7 +29,7 @@ def alt_network_config() -> NetworkConfig:
         laptop_ip="198.51.100.100",
         netmask="255.255.255.0",
         mgmt_network="203.0.113.0/24",
-        device_name="Secondary Test Device"
+        device_name="Secondary Test Device",
     )
 
 
@@ -43,7 +43,7 @@ def protected_interface() -> NetworkInterface:
         is_active=True,
         is_protected=True,
         current_ip="192.168.1.100",
-        mac_address="aa:bb:cc:dd:ee:ff"
+        mac_address="aa:bb:cc:dd:ee:ff",
     )
 
 
@@ -58,7 +58,7 @@ def usb_interface_active() -> NetworkInterface:
         is_protected=False,
         current_ip=None,
         mac_address="11:22:33:44:55:66",
-        vendor="Realtek"
+        vendor="Realtek",
     )
 
 
@@ -73,14 +73,14 @@ def usb_interface_inactive() -> NetworkInterface:
         is_protected=False,
         current_ip=None,
         mac_address="77:88:99:aa:bb:cc",
-        vendor="ASIX"
+        vendor="ASIX",
     )
 
 
 @pytest.fixture
 def mock_macos_detector():
     """Mock macOS detector with pre-configured interfaces"""
-    with patch('darwin_mgmt_nic.macos.MacOSUSBNICDetector') as mock:
+    with patch("darwin_mgmt_nic.macos.MacOSUSBNICDetector") as mock:
         detector = MagicMock()
         detector.detect_interfaces.return_value = [
             NetworkInterface(
@@ -90,7 +90,7 @@ def mock_macos_detector():
                 is_active=True,
                 is_protected=True,
                 current_ip="192.168.1.100",
-                mac_address="aa:bb:cc:dd:ee:ff"
+                mac_address="aa:bb:cc:dd:ee:ff",
             ),
             NetworkInterface(
                 name="en7",
@@ -100,7 +100,7 @@ def mock_macos_detector():
                 is_protected=False,
                 current_ip=None,
                 mac_address="11:22:33:44:55:66",
-                vendor="Realtek"
+                vendor="Realtek",
             ),
         ]
         detector.get_interface_status.return_value = True
@@ -115,7 +115,7 @@ def mock_macos_detector():
 @pytest.fixture
 def mock_subprocess_networksetup():
     """Mock subprocess for networksetup command"""
-    with patch('subprocess.run') as mock_run:
+    with patch("subprocess.run") as mock_run:
         mock_run.return_value = MagicMock(
             returncode=0,
             stdout="""Hardware Port: Wi-Fi
@@ -126,7 +126,7 @@ Hardware Port: USB 10/100/1000 LAN
 Device: en7
 Ethernet Address: 11:22:33:44:55:66
 """,
-            stderr=""
+            stderr="",
         )
         yield mock_run
 
@@ -134,7 +134,7 @@ Ethernet Address: 11:22:33:44:55:66
 @pytest.fixture
 def mock_subprocess_ifconfig():
     """Mock subprocess for ifconfig command"""
-    with patch('subprocess.run') as mock_run:
+    with patch("subprocess.run") as mock_run:
         mock_run.return_value = MagicMock(
             returncode=0,
             stdout="""en7: flags=8863<UP,BROADCAST,SMART,RUNNING,SIMPLEX,MULTICAST> mtu 1500
@@ -142,6 +142,6 @@ def mock_subprocess_ifconfig():
 \tinet 192.0.2.100 netmask 0xffffff00 broadcast 192.0.2.255
 \tstatus: active
 """,
-            stderr=""
+            stderr="",
         )
         yield mock_run

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -3,12 +3,40 @@ Tests for app-level operator diagnostics.
 """
 
 import argparse
+import subprocess
 import sys
+from pathlib import Path
 from unittest.mock import MagicMock
 
-from darwin_mgmt_nic.app import cmd_configure, print_bastion_diagnostics
+import pytest
+
+from darwin_mgmt_nic.app import (
+    cmd_configure,
+    cmd_dashboard,
+    cmd_init_config,
+    cmd_list_profiles,
+    cmd_restore,
+    cmd_show_config,
+    cmd_status,
+    cmd_test,
+    main,
+    print_bastion_diagnostics,
+)
 from darwin_mgmt_nic.macos import BastionDiagnostics
 from darwin_mgmt_nic.settings import NetworkProfile, Settings
+
+
+class FakeConsole:
+    """Small console test double that records printed objects."""
+
+    instances = []
+
+    def __init__(self):
+        self.printed = []
+        self.__class__.instances.append(self)
+
+    def print(self, *objects, **kwargs):
+        self.printed.append(objects)
 
 
 class TestPrintBastionDiagnostics:
@@ -61,6 +89,7 @@ class TestCmdConfigure:
 
         def fake_cli_main():
             called["argv"] = list(sys.argv)
+            return 7
 
         monkeypatch.setattr("darwin_mgmt_nic.cli.main", fake_cli_main)
 
@@ -70,7 +99,7 @@ class TestCmdConfigure:
                     device_ip="192.168.88.1",
                     laptop_ip="192.168.88.100",
                     mgmt_network="192.168.88.0/24",
-                    device_name="CRS309 Bastion",
+                    device_name="Lab Management Device",
                 )
             }
         )
@@ -86,7 +115,7 @@ class TestCmdConfigure:
             show_dashboard=False,
         )
 
-        assert cmd_configure(args, settings) is None
+        assert cmd_configure(args, settings) == 7
 
         assert called["argv"] == [
             "darwin-mgmt-nic",
@@ -99,7 +128,7 @@ class TestCmdConfigure:
             "--mgmt-network",
             "192.168.88.0/24",
             "--device-name",
-            "CRS309 Bastion",
+            "Lab Management Device",
             "--dry-run",
             "--preserve-wifi",
         ]
@@ -120,3 +149,305 @@ class TestCmdConfigure:
 
         assert cmd_configure(args, Settings()) == 1
         assert "--device-ip and --laptop-ip are required" in capsys.readouterr().out
+
+
+class TestStatusAndDashboardCommands:
+    """Test non-mutating dashboard/status command wiring."""
+
+    def test_status_builds_dashboard_and_prints_bastion_diagnostics(self, monkeypatch):
+        calls = {}
+
+        class FakeDashboard:
+            def __init__(self, wifi_monitor, service_manager):
+                calls["dashboard_args"] = (wifi_monitor, service_manager)
+                calls["display_status"] = 0
+                calls["connectivity"] = 0
+
+            def display_status(self):
+                calls["display_status"] += 1
+
+            def show_connectivity_metrics(self):
+                calls["connectivity"] += 1
+
+        monkeypatch.setattr("rich.console.Console", FakeConsole)
+        monkeypatch.setattr("darwin_mgmt_nic.network_manager.WiFiMonitor", lambda: "wifi-monitor")
+        monkeypatch.setattr("darwin_mgmt_nic.network_manager.ServiceOrderManager", lambda: "service-manager")
+        monkeypatch.setattr("darwin_mgmt_nic.network_manager.NetworkDashboard", FakeDashboard)
+        monkeypatch.setattr(
+            "darwin_mgmt_nic.app.print_bastion_diagnostics", lambda console: calls.setdefault("bastion", console)
+        )
+        FakeConsole.instances.clear()
+
+        cmd_status(argparse.Namespace())
+
+        assert calls["dashboard_args"] == ("wifi-monitor", "service-manager")
+        assert calls["display_status"] == 1
+        assert calls["connectivity"] == 1
+        assert calls["bastion"] is FakeConsole.instances[0]
+        assert FakeConsole.instances[0].printed
+
+    def test_dashboard_defaults_to_static_status(self, monkeypatch):
+        calls = {}
+
+        class FakeDashboard:
+            def __init__(self, wifi_monitor, service_manager):
+                calls["dashboard_args"] = (wifi_monitor, service_manager)
+
+            def display_status(self):
+                calls["display_status"] = calls.get("display_status", 0) + 1
+
+            def monitor_interference(self, duration):
+                calls["monitor_interference"] = duration
+
+        monkeypatch.setattr("darwin_mgmt_nic.network_manager.WiFiMonitor", lambda: "wifi-monitor")
+        monkeypatch.setattr("darwin_mgmt_nic.network_manager.ServiceOrderManager", lambda: "service-manager")
+        monkeypatch.setattr("darwin_mgmt_nic.network_manager.NetworkDashboard", FakeDashboard)
+
+        cmd_dashboard(argparse.Namespace(interference=False, duration=None))
+
+        assert calls["dashboard_args"] == ("wifi-monitor", "service-manager")
+        assert calls["display_status"] == 1
+        assert "monitor_interference" not in calls
+
+    def test_dashboard_interference_uses_default_duration(self, monkeypatch):
+        calls = {}
+
+        class FakeDashboard:
+            def __init__(self, wifi_monitor, service_manager):
+                pass
+
+            def display_status(self):
+                calls["display_status"] = True
+
+            def monitor_interference(self, duration):
+                calls["monitor_interference"] = duration
+
+        monkeypatch.setattr("darwin_mgmt_nic.network_manager.WiFiMonitor", lambda: object())
+        monkeypatch.setattr("darwin_mgmt_nic.network_manager.ServiceOrderManager", lambda: object())
+        monkeypatch.setattr("darwin_mgmt_nic.network_manager.NetworkDashboard", FakeDashboard)
+
+        cmd_dashboard(argparse.Namespace(interference=True, duration=None))
+
+        assert calls["monitor_interference"] == 30
+        assert "display_status" not in calls
+
+
+class TestUtilityCommands:
+    """Test app-level utility subcommands without touching host state."""
+
+    def test_cmd_test_runs_expected_interface_and_ping_checks(self, monkeypatch):
+        commands = []
+
+        def fake_run(cmd, **kwargs):
+            commands.append(cmd)
+            if cmd[0] == "ifconfig":
+                return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+            if cmd[-1] == "192.0.2.1":
+                return subprocess.CompletedProcess(cmd, 0, stdout="64 bytes time=12.3 ms", stderr="")
+            return subprocess.CompletedProcess(cmd, 1, stdout="", stderr="timeout")
+
+        monkeypatch.setattr("rich.console.Console", FakeConsole)
+        monkeypatch.setattr("darwin_mgmt_nic.app.subprocess.run", fake_run)
+        FakeConsole.instances.clear()
+
+        cmd_test(argparse.Namespace())
+
+        assert commands == [
+            ["ifconfig", "en0"],
+            ["ifconfig", "en1"],
+            ["ifconfig", "en11"],
+            ["ping", "-c", "1", "-W", "2", "192.0.2.1"],
+            ["ping", "-c", "1", "-W", "2", "192.168.1.1"],
+            ["ping", "-c", "1", "-W", "2", "8.8.8.8"],
+        ]
+        assert len(FakeConsole.instances[0].printed) == 1
+
+    def test_cmd_test_records_errors_without_raising(self, monkeypatch):
+        def fake_run(cmd, **kwargs):
+            raise OSError("command unavailable")
+
+        monkeypatch.setattr("rich.console.Console", FakeConsole)
+        monkeypatch.setattr("darwin_mgmt_nic.app.subprocess.run", fake_run)
+        FakeConsole.instances.clear()
+
+        cmd_test(argparse.Namespace())
+
+        assert len(FakeConsole.instances[0].printed) == 1
+
+    @pytest.mark.parametrize(
+        ("restore_result", "expected"),
+        [
+            (True, "[OK] Service order restored"),
+            (False, "[FAIL] Failed to restore service order"),
+        ],
+    )
+    def test_restore_reports_service_order_result(self, monkeypatch, capsys, restore_result, expected):
+        class FakeServiceOrderManager:
+            def restore_service_order(self):
+                return restore_result
+
+        monkeypatch.setattr("darwin_mgmt_nic.network_manager.ServiceOrderManager", FakeServiceOrderManager)
+
+        cmd_restore(argparse.Namespace())
+
+        output = capsys.readouterr().out
+        assert "[*] Restoring network configuration..." in output
+        assert expected in output
+        assert "[OK] Configuration restore complete" in output
+
+    def test_show_config_prints_sources_paths_settings_and_profiles(self, monkeypatch, tmp_path):
+        existing = tmp_path / "config.toml"
+        existing.write_text("[defaults]\n")
+        missing = tmp_path / "missing.toml"
+        settings = Settings(
+            device_ip="192.168.88.1",
+            laptop_ip="192.168.88.100",
+            mgmt_network="192.168.88.0/24",
+            default_profile="homelab",
+            config_sources=[str(existing)],
+            profiles={
+                "homelab": NetworkProfile(
+                    device_ip="192.168.88.1",
+                    laptop_ip="192.168.88.100",
+                    device_name="Lab Management Device",
+                )
+            },
+        )
+
+        monkeypatch.setattr("rich.console.Console", FakeConsole)
+        monkeypatch.setattr("darwin_mgmt_nic.app.get_config_paths", lambda: [existing, missing])
+        FakeConsole.instances.clear()
+
+        cmd_show_config(settings)
+
+        printed = "\n".join(str(item) for call in FakeConsole.instances[0].printed for item in call)
+        assert "Configuration Sources" in printed
+        assert str(existing) in printed
+        assert str(missing) in printed
+        assert "Current Settings" in printed
+        assert "Available Profiles" in printed
+
+    def test_init_config_reports_created_and_existing_config(self, monkeypatch, capsys):
+        monkeypatch.setattr("darwin_mgmt_nic.app.init_config", lambda: Path("/tmp/darwin-nic/config.toml"))
+
+        cmd_init_config()
+
+        assert "Config file created: /tmp/darwin-nic/config.toml" in capsys.readouterr().out
+
+        monkeypatch.setattr("darwin_mgmt_nic.app.init_config", lambda: None)
+
+        cmd_init_config()
+
+        assert "Config file already exists" in capsys.readouterr().out
+
+    def test_list_profiles_reports_empty_state(self, monkeypatch):
+        monkeypatch.setattr("rich.console.Console", FakeConsole)
+        FakeConsole.instances.clear()
+
+        cmd_list_profiles(Settings())
+
+        printed = "\n".join(str(item) for call in FakeConsole.instances[0].printed for item in call)
+        assert "No profiles configured" in printed
+        assert "darwin-nic init-config" in printed
+
+    def test_list_profiles_prints_profile_details(self, monkeypatch):
+        settings = Settings(
+            default_profile="homelab",
+            profiles={
+                "homelab": NetworkProfile(
+                    device_ip="192.168.88.1",
+                    laptop_ip="192.168.88.100",
+                    mgmt_network="192.168.88.0/24",
+                    device_name="Lab Management Device",
+                    description="USB OOB management path",
+                )
+            },
+        )
+        monkeypatch.setattr("rich.console.Console", FakeConsole)
+        FakeConsole.instances.clear()
+
+        cmd_list_profiles(settings)
+
+        printed = "\n".join(str(item) for call in FakeConsole.instances[0].printed for item in call)
+        assert "Available Profiles" in printed
+        assert "homelab" in printed
+        assert "Lab Management Device" in printed
+        assert "192.168.88.1 -> 192.168.88.100" in printed
+        assert "USB OOB management path" in printed
+
+
+class TestMainDispatch:
+    """Test installed console-script dispatcher behavior."""
+
+    def test_no_command_prints_help_and_returns_error(self, monkeypatch, capsys):
+        monkeypatch.setattr("darwin_mgmt_nic.app.load_settings", lambda: Settings())
+        monkeypatch.setattr(sys, "argv", ["darwin-nic"])
+
+        assert main() == 1
+        assert "Available commands" in capsys.readouterr().out
+
+    @pytest.mark.parametrize(
+        ("argv", "patched_name"),
+        [
+            (["darwin-nic", "setup"], "cmd_setup"),
+            (["darwin-nic", "status"], "cmd_status"),
+            (["darwin-nic", "test"], "cmd_test"),
+            (["darwin-nic", "restore"], "cmd_restore"),
+            (["darwin-nic", "config"], "cmd_show_config"),
+            (["darwin-nic", "init-config"], "cmd_init_config"),
+            (["darwin-nic", "profiles"], "cmd_list_profiles"),
+            (["darwin-nic", "dashboard", "--interference", "--duration", "5"], "cmd_dashboard"),
+        ],
+    )
+    def test_main_dispatches_subcommands(self, monkeypatch, argv, patched_name):
+        calls = []
+
+        def fake_command(*args):
+            calls.append((patched_name, args))
+
+        monkeypatch.setattr("darwin_mgmt_nic.app.load_settings", lambda: Settings())
+        monkeypatch.setattr(f"darwin_mgmt_nic.app.{patched_name}", fake_command)
+        monkeypatch.setattr(sys, "argv", argv)
+
+        assert main() == 0
+        assert calls
+
+    def test_main_returns_configure_error_code(self, monkeypatch):
+        monkeypatch.setattr("darwin_mgmt_nic.app.load_settings", lambda: Settings())
+        monkeypatch.setattr("darwin_mgmt_nic.app.cmd_configure", lambda args, settings: 7)
+        monkeypatch.setattr(sys, "argv", ["darwin-nic", "configure"])
+
+        assert main() == 7
+
+    def test_main_returns_success_when_configure_returns_none(self, monkeypatch):
+        monkeypatch.setattr("darwin_mgmt_nic.app.load_settings", lambda: Settings())
+        monkeypatch.setattr("darwin_mgmt_nic.app.cmd_configure", lambda args, settings: None)
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            ["darwin-nic", "configure", "--device-ip", "192.0.2.1", "--laptop-ip", "192.0.2.100"],
+        )
+
+        assert main() == 0
+
+    def test_main_handles_keyboard_interrupt(self, monkeypatch, capsys):
+        def raise_keyboard_interrupt(args):
+            raise KeyboardInterrupt
+
+        monkeypatch.setattr("darwin_mgmt_nic.app.load_settings", lambda: Settings())
+        monkeypatch.setattr("darwin_mgmt_nic.app.cmd_status", raise_keyboard_interrupt)
+        monkeypatch.setattr(sys, "argv", ["darwin-nic", "status"])
+
+        assert main() == 1
+        assert "Operation cancelled by user" in capsys.readouterr().out
+
+    def test_main_handles_unexpected_exception(self, monkeypatch, capsys):
+        def raise_runtime_error(args):
+            raise RuntimeError("boom")
+
+        monkeypatch.setattr("darwin_mgmt_nic.app.load_settings", lambda: Settings())
+        monkeypatch.setattr("darwin_mgmt_nic.app.cmd_status", raise_runtime_error)
+        monkeypatch.setattr(sys, "argv", ["darwin-nic", "status"])
+
+        assert main() == 1
+        assert "[FAIL] Error: boom" in capsys.readouterr().out

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,435 @@
+"""
+Tests for the configure backend CLI.
+"""
+
+import logging
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from darwin_mgmt_nic import cli
+from darwin_mgmt_nic.settings import NetworkProfile, Settings
+
+
+class FakeConsole:
+    """Small console test double that records printed objects."""
+
+    instances = []
+
+    def __init__(self):
+        self.printed = []
+        self.__class__.instances.append(self)
+
+    def print(self, *objects, **kwargs):
+        self.printed.append(objects)
+
+
+def rendered_console() -> str:
+    """Return all text-ish objects printed through the latest FakeConsole."""
+    return "\n".join(str(item) for call in FakeConsole.instances[-1].printed for item in call)
+
+
+def install_fake_configurator(monkeypatch, *, result=True, exc=None):
+    """Patch USBNICConfigurator and capture constructor inputs."""
+    captured = {}
+
+    class FakeConfigurator:
+        def __init__(self, config, dry_run=False, preserve_wifi=True, show_dashboard=False):
+            captured["config"] = config
+            captured["dry_run"] = dry_run
+            captured["preserve_wifi"] = preserve_wifi
+            captured["show_dashboard"] = show_dashboard
+
+        def configure(self):
+            if exc:
+                raise exc
+            return result
+
+    monkeypatch.setattr("darwin_mgmt_nic.cli.USBNICConfigurator", FakeConfigurator)
+    return captured
+
+
+class TestParserAndDisplay:
+    """Test parser defaults and config/profile display helpers."""
+
+    def test_setup_logging_sets_expected_basic_config(self, monkeypatch):
+        calls = []
+
+        def fake_basic_config(**kwargs):
+            calls.append(kwargs)
+
+        monkeypatch.setattr("darwin_mgmt_nic.cli.logging.basicConfig", fake_basic_config)
+
+        cli.setup_logging(verbose=True)
+        cli.setup_logging(verbose=False)
+
+        assert calls[0]["level"] == logging.DEBUG
+        assert calls[1]["level"] == logging.INFO
+        assert calls[0]["format"] == "[%(asctime)s] %(levelname)s: %(message)s"
+        assert calls[0]["datefmt"] == "%Y-%m-%d %H:%M:%S"
+
+    def test_create_parser_uses_settings_defaults(self):
+        settings = Settings(
+            device_ip="192.168.88.1",
+            laptop_ip="192.168.88.100",
+            netmask="255.255.0.0",
+            mgmt_network="192.168.88.0/24",
+            device_name="Lab Management Device",
+            dry_run=True,
+            preserve_wifi=False,
+            show_dashboard=True,
+        )
+
+        parser = cli.create_parser(settings)
+        args = parser.parse_args([])
+
+        assert args.device_ip == "192.168.88.1"
+        assert args.laptop_ip == "192.168.88.100"
+        assert args.netmask == "255.255.0.0"
+        assert args.mgmt_network == "192.168.88.0/24"
+        assert args.device_name == "Lab Management Device"
+        assert args.dry_run is True
+        assert args.preserve_wifi is False
+        assert args.show_dashboard is True
+
+    def test_show_config_prints_sources_paths_settings_and_profiles(self, monkeypatch, tmp_path):
+        existing = tmp_path / "config.toml"
+        existing.write_text("[defaults]\n")
+        missing = tmp_path / "missing.toml"
+        settings = Settings(
+            device_ip="192.168.88.1",
+            laptop_ip="192.168.88.100",
+            mgmt_network="192.168.88.0/24",
+            default_profile="homelab",
+            config_sources=[str(existing)],
+            profiles={
+                "homelab": NetworkProfile(
+                    device_ip="192.168.88.1",
+                    laptop_ip="192.168.88.100",
+                    device_name="Lab Management Device",
+                )
+            },
+        )
+        monkeypatch.setattr("darwin_mgmt_nic.cli.Console", FakeConsole)
+        monkeypatch.setattr("darwin_mgmt_nic.cli.get_config_paths", lambda: [existing, missing])
+        FakeConsole.instances.clear()
+
+        cli.show_config(settings)
+
+        printed = rendered_console()
+        assert "Configuration Sources" in printed
+        assert str(existing) in printed
+        assert str(missing) in printed
+        assert "Current Settings" in printed
+        assert "Available Profiles" in printed
+
+    def test_list_profiles_reports_empty_state(self, monkeypatch):
+        monkeypatch.setattr("darwin_mgmt_nic.cli.Console", FakeConsole)
+        FakeConsole.instances.clear()
+
+        cli.list_profiles(Settings())
+
+        printed = rendered_console()
+        assert "No profiles configured" in printed
+        assert "darwin-nic --init-config" in printed
+
+    def test_list_profiles_prints_profile_details(self, monkeypatch):
+        monkeypatch.setattr("darwin_mgmt_nic.cli.Console", FakeConsole)
+        FakeConsole.instances.clear()
+        settings = Settings(
+            default_profile="homelab",
+            profiles={
+                "homelab": NetworkProfile(
+                    device_ip="192.168.88.1",
+                    laptop_ip="192.168.88.100",
+                    mgmt_network="192.168.88.0/24",
+                    device_name="Lab Management Device",
+                    description="USB OOB management path",
+                )
+            },
+        )
+
+        cli.list_profiles(settings)
+
+        printed = rendered_console()
+        assert "Available Profiles" in printed
+        assert "homelab" in printed
+        assert "Lab Management Device" in printed
+        assert "192.168.88.1 -> 192.168.88.100" in printed
+        assert "USB OOB management path" in printed
+
+
+class TestMain:
+    """Test CLI backend entrypoint behavior."""
+
+    def test_main_init_config_created_and_existing(self, monkeypatch):
+        monkeypatch.setattr("darwin_mgmt_nic.cli.Console", FakeConsole)
+        monkeypatch.setattr("darwin_mgmt_nic.cli.load_settings", lambda profile=None: Settings())
+        monkeypatch.setattr("darwin_mgmt_nic.cli.init_config", lambda: Path("/tmp/darwin-nic/config.toml"))
+        monkeypatch.setattr(sys, "argv", ["darwin-nic", "--init-config"])
+        FakeConsole.instances.clear()
+
+        assert cli.main() == 0
+        assert "Config file created: /tmp/darwin-nic/config.toml" in rendered_console()
+
+        monkeypatch.setattr("darwin_mgmt_nic.cli.init_config", lambda: None)
+        FakeConsole.instances.clear()
+
+        assert cli.main() == 0
+        assert "Config file already exists" in rendered_console()
+
+    @pytest.mark.parametrize(
+        ("argv", "patched_name"),
+        [
+            (["darwin-nic", "--show-config"], "show_config"),
+            (["darwin-nic", "--list-profiles"], "list_profiles"),
+        ],
+    )
+    def test_main_dispatches_config_management_commands(self, monkeypatch, argv, patched_name):
+        calls = []
+
+        monkeypatch.setattr("darwin_mgmt_nic.cli.Console", FakeConsole)
+        monkeypatch.setattr("darwin_mgmt_nic.cli.load_settings", lambda profile=None: Settings())
+        monkeypatch.setattr(f"darwin_mgmt_nic.cli.{patched_name}", lambda settings: calls.append(settings))
+        monkeypatch.setattr(sys, "argv", argv)
+
+        assert cli.main() == 0
+        assert len(calls) == 1
+
+    def test_main_returns_unsupported_platform_code_before_configuring(self, monkeypatch):
+        captured = install_fake_configurator(monkeypatch)
+        monkeypatch.setattr("darwin_mgmt_nic.cli.load_settings", lambda profile=None: Settings())
+        monkeypatch.setattr("darwin_mgmt_nic.cli.USBNICDetectorFactory.is_supported", lambda: False)
+        monkeypatch.setattr(sys, "argv", ["darwin-nic"])
+
+        assert cli.main() == 3
+        assert captured == {}
+
+    def test_main_configures_with_profile_values(self, monkeypatch):
+        settings = Settings(
+            profiles={
+                "homelab": NetworkProfile(
+                    device_ip="192.168.88.1",
+                    laptop_ip="192.168.88.100",
+                    netmask="255.255.255.0",
+                    mgmt_network="192.168.88.0/24",
+                    device_name="Lab Management Device",
+                )
+            }
+        )
+        load_calls = []
+        captured = install_fake_configurator(monkeypatch, result=True)
+        monkeypatch.setattr("darwin_mgmt_nic.cli.Console", FakeConsole)
+        monkeypatch.setattr(
+            "darwin_mgmt_nic.cli.load_settings",
+            lambda profile=None: load_calls.append(profile) or settings,
+        )
+        monkeypatch.setattr("darwin_mgmt_nic.cli.USBNICDetectorFactory.is_supported", lambda: True)
+        monkeypatch.setattr(sys, "argv", ["darwin-nic", "--profile", "homelab", "--dry-run", "--show-dashboard"])
+        FakeConsole.instances.clear()
+
+        assert cli.main() == 0
+        assert load_calls == ["homelab"]
+        assert captured["config"].device_ip == "192.168.88.1"
+        assert captured["config"].laptop_ip == "192.168.88.100"
+        assert captured["config"].mgmt_network == "192.168.88.0/24"
+        assert captured["config"].device_name == "Lab Management Device"
+        assert captured["dry_run"] is True
+        assert captured["preserve_wifi"] is True
+        assert captured["show_dashboard"] is True
+        assert "Using profile: homelab" in rendered_console()
+
+    def test_main_warns_for_missing_profile_and_uses_defaults(self, monkeypatch):
+        settings = Settings(
+            device_ip="192.0.2.1",
+            laptop_ip="192.0.2.100",
+            profiles={
+                "known": NetworkProfile(
+                    device_ip="198.51.100.1",
+                    laptop_ip="198.51.100.100",
+                )
+            },
+        )
+        captured = install_fake_configurator(monkeypatch, result=True)
+        monkeypatch.setattr("darwin_mgmt_nic.cli.Console", FakeConsole)
+        monkeypatch.setattr("darwin_mgmt_nic.cli.load_settings", lambda profile=None: settings)
+        monkeypatch.setattr("darwin_mgmt_nic.cli.USBNICDetectorFactory.is_supported", lambda: True)
+        monkeypatch.setattr(sys, "argv", ["darwin-nic", "--profile", "missing"])
+        FakeConsole.instances.clear()
+
+        assert cli.main() == 0
+        assert captured["config"].device_ip == "192.0.2.1"
+        assert captured["config"].laptop_ip == "192.0.2.100"
+        printed = rendered_console()
+        assert "Profile 'missing' not found" in printed
+        assert "known" in printed
+
+    @pytest.mark.parametrize(("configure_result", "exit_code"), [(True, 0), (False, 1)])
+    def test_main_returns_configurator_result(self, monkeypatch, configure_result, exit_code):
+        install_fake_configurator(monkeypatch, result=configure_result)
+        monkeypatch.setattr("darwin_mgmt_nic.cli.load_settings", lambda profile=None: Settings())
+        monkeypatch.setattr("darwin_mgmt_nic.cli.USBNICDetectorFactory.is_supported", lambda: True)
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            ["darwin-nic", "--device-ip", "192.0.2.1", "--laptop-ip", "192.0.2.100"],
+        )
+
+        assert cli.main() == exit_code
+
+    def test_main_returns_configuration_error_code_for_invalid_network_config(self, monkeypatch):
+        monkeypatch.setattr("darwin_mgmt_nic.cli.load_settings", lambda profile=None: Settings())
+        monkeypatch.setattr("darwin_mgmt_nic.cli.USBNICDetectorFactory.is_supported", lambda: True)
+        monkeypatch.setattr(sys, "argv", ["darwin-nic", "--device-ip", "not-an-ip"])
+
+        assert cli.main() == 2
+
+    def test_main_handles_keyboard_interrupt(self, monkeypatch):
+        install_fake_configurator(monkeypatch, exc=KeyboardInterrupt())
+        monkeypatch.setattr("darwin_mgmt_nic.cli.load_settings", lambda profile=None: Settings())
+        monkeypatch.setattr("darwin_mgmt_nic.cli.USBNICDetectorFactory.is_supported", lambda: True)
+        monkeypatch.setattr(sys, "argv", ["darwin-nic"])
+
+        assert cli.main() == 130
+
+    def test_main_handles_unexpected_exception(self, monkeypatch):
+        install_fake_configurator(monkeypatch, exc=RuntimeError("boom"))
+        monkeypatch.setattr("darwin_mgmt_nic.cli.load_settings", lambda profile=None: Settings())
+        monkeypatch.setattr("darwin_mgmt_nic.cli.USBNICDetectorFactory.is_supported", lambda: True)
+        monkeypatch.setattr(sys, "argv", ["darwin-nic", "--verbose"])
+
+        assert cli.main() == 1
+
+    def test_main_dispatches_vpn_repair_mode(self, monkeypatch):
+        monkeypatch.setattr("darwin_mgmt_nic.cli.load_settings", lambda profile=None: Settings())
+        monkeypatch.setattr("darwin_mgmt_nic.cli.USBNICDetectorFactory.is_supported", lambda: True)
+        monkeypatch.setattr("darwin_mgmt_nic.cli.handle_vpn_repair", lambda: 9)
+        monkeypatch.setattr(sys, "argv", ["darwin-nic", "--fix-vpn-issues"])
+
+        assert cli.main() == 9
+
+
+class TestVpnRepair:
+    """Test VPN repair workflow with all host operations mocked."""
+
+    def test_handle_vpn_repair_success(self, monkeypatch):
+        calls = []
+
+        class FakeServiceOrderManager:
+            def backup_service_order(self):
+                calls.append("backup")
+
+            def set_wifi_priority(self):
+                calls.append("set_wifi_priority")
+                return True
+
+        def fake_run(cmd, **kwargs):
+            calls.append(cmd)
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+        monkeypatch.setattr("darwin_mgmt_nic.cli.Console", FakeConsole)
+        monkeypatch.setattr("darwin_mgmt_nic.network_manager.ServiceOrderManager", FakeServiceOrderManager)
+        monkeypatch.setattr("darwin_mgmt_nic.cli.subprocess.run", fake_run)
+        monkeypatch.setattr("darwin_mgmt_nic.cli.time.sleep", lambda seconds: calls.append(["sleep", seconds]))
+        FakeConsole.instances.clear()
+
+        assert cli.handle_vpn_repair() == 0
+        assert calls[0:2] == ["backup", "set_wifi_priority"]
+        assert ["sleep", 3] in calls
+        assert ["nslookup", "google.com"] in calls
+        assert ["ping", "-c", "1", "-t", "5", "8.8.8.8"] in calls
+        assert "Network repair completed successfully" in rendered_console()
+
+    def test_handle_vpn_repair_stops_when_wifi_priority_fails(self, monkeypatch):
+        class FakeServiceOrderManager:
+            def backup_service_order(self):
+                pass
+
+            def set_wifi_priority(self):
+                return False
+
+        monkeypatch.setattr("darwin_mgmt_nic.cli.Console", FakeConsole)
+        monkeypatch.setattr("darwin_mgmt_nic.network_manager.ServiceOrderManager", FakeServiceOrderManager)
+        FakeConsole.instances.clear()
+
+        assert cli.handle_vpn_repair() == 1
+        assert "Failed to restore WiFi priority" in rendered_console()
+
+    def test_handle_vpn_repair_reports_dns_update_failure(self, monkeypatch):
+        class FakeServiceOrderManager:
+            def backup_service_order(self):
+                pass
+
+            def set_wifi_priority(self):
+                return True
+
+        def fake_run(cmd, **kwargs):
+            raise subprocess.CalledProcessError(1, cmd)
+
+        monkeypatch.setattr("darwin_mgmt_nic.cli.Console", FakeConsole)
+        monkeypatch.setattr("darwin_mgmt_nic.network_manager.ServiceOrderManager", FakeServiceOrderManager)
+        monkeypatch.setattr("darwin_mgmt_nic.cli.subprocess.run", fake_run)
+        FakeConsole.instances.clear()
+
+        assert cli.handle_vpn_repair() == 1
+        assert "Failed to fix DNS" in rendered_console()
+
+    def test_handle_vpn_repair_reports_verification_failure(self, monkeypatch):
+        class FakeServiceOrderManager:
+            def backup_service_order(self):
+                pass
+
+            def set_wifi_priority(self):
+                return True
+
+        def fake_run(cmd, **kwargs):
+            returncode = 1 if cmd[0] == "ping" else 0
+            return subprocess.CompletedProcess(cmd, returncode, stdout="", stderr="")
+
+        monkeypatch.setattr("darwin_mgmt_nic.cli.Console", FakeConsole)
+        monkeypatch.setattr("darwin_mgmt_nic.network_manager.ServiceOrderManager", FakeServiceOrderManager)
+        monkeypatch.setattr("darwin_mgmt_nic.cli.subprocess.run", fake_run)
+        monkeypatch.setattr("darwin_mgmt_nic.cli.time.sleep", lambda seconds: None)
+        FakeConsole.instances.clear()
+
+        assert cli.handle_vpn_repair() == 1
+        printed = rendered_console()
+        assert "Network verification failed" in printed
+        assert "DNS: Working" in printed
+        assert "Internet: Broken" in printed
+
+    def test_handle_vpn_repair_reports_verification_timeout(self, monkeypatch):
+        class FakeServiceOrderManager:
+            def backup_service_order(self):
+                pass
+
+            def set_wifi_priority(self):
+                return True
+
+        def fake_run(cmd, **kwargs):
+            if cmd[0] == "nslookup":
+                raise subprocess.TimeoutExpired(cmd, 10)
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+        monkeypatch.setattr("darwin_mgmt_nic.cli.Console", FakeConsole)
+        monkeypatch.setattr("darwin_mgmt_nic.network_manager.ServiceOrderManager", FakeServiceOrderManager)
+        monkeypatch.setattr("darwin_mgmt_nic.cli.subprocess.run", fake_run)
+        monkeypatch.setattr("darwin_mgmt_nic.cli.time.sleep", lambda seconds: None)
+        FakeConsole.instances.clear()
+
+        assert cli.handle_vpn_repair() == 1
+        assert "Network verification timed out" in rendered_console()
+
+    def test_handle_vpn_repair_handles_keyboard_interrupt(self, monkeypatch):
+        class InterruptingServiceOrderManager:
+            def __init__(self):
+                raise KeyboardInterrupt
+
+        monkeypatch.setattr("darwin_mgmt_nic.cli.Console", FakeConsole)
+        monkeypatch.setattr("darwin_mgmt_nic.network_manager.ServiceOrderManager", InterruptingServiceOrderManager)
+        FakeConsole.instances.clear()
+
+        assert cli.handle_vpn_repair() == 130
+        assert "VPN repair cancelled by user" in rendered_console()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,7 +3,8 @@ Tests for configuration models
 """
 
 import pytest
-from darwin_mgmt_nic.config import NetworkConfig, NetworkInterface, OSType
+
+from darwin_mgmt_nic.config import NetworkConfig, OSType
 
 
 class TestNetworkConfig:
@@ -24,7 +25,7 @@ class TestNetworkConfig:
                 laptop_ip="192.0.2.100",
                 netmask="255.255.255.0",
                 mgmt_network="198.51.100.0/24",
-                device_name="Test"
+                device_name="Test",
             )
 
     def test_invalid_laptop_ip(self):
@@ -35,7 +36,7 @@ class TestNetworkConfig:
                 laptop_ip="not.an.ip.address",
                 netmask="255.255.255.0",
                 mgmt_network="198.51.100.0/24",
-                device_name="Test"
+                device_name="Test",
             )
 
     def test_invalid_mgmt_network(self):
@@ -46,7 +47,7 @@ class TestNetworkConfig:
                 laptop_ip="192.0.2.100",
                 netmask="255.255.255.0",
                 mgmt_network="not.a.network/24",
-                device_name="Test"
+                device_name="Test",
             )
 
     def test_get_mgmt_gateway(self, sample_network_config):

--- a/tests/test_configurator.py
+++ b/tests/test_configurator.py
@@ -2,8 +2,8 @@
 Tests for main configurator
 """
 
-import pytest
 from unittest.mock import ANY, MagicMock, patch
+
 from darwin_mgmt_nic.configurator import USBNICConfigurator
 
 
@@ -20,96 +20,53 @@ class TestUSBNICConfigurator:
     def test_init_with_custom_detector(self, sample_network_config):
         """Test configurator with custom detector"""
         mock_detector = MagicMock()
-        configurator = USBNICConfigurator(
-            sample_network_config,
-            detector=mock_detector
-        )
+        configurator = USBNICConfigurator(sample_network_config, detector=mock_detector)
         assert configurator.detector == mock_detector
 
-    def test_find_best_usb_interface_active(
-        self,
-        sample_network_config,
-        usb_interface_active,
-        protected_interface
-    ):
+    def test_find_best_usb_interface_active(self, sample_network_config, usb_interface_active, protected_interface):
         """Test finding best USB interface with active USB"""
         mock_detector = MagicMock()
-        mock_detector.detect_interfaces.return_value = [
-            protected_interface,
-            usb_interface_active
-        ]
+        mock_detector.detect_interfaces.return_value = [protected_interface, usb_interface_active]
 
-        configurator = USBNICConfigurator(
-            sample_network_config,
-            detector=mock_detector
-        )
+        configurator = USBNICConfigurator(sample_network_config, detector=mock_detector)
 
         interface = configurator.find_best_usb_interface()
         assert interface == usb_interface_active
 
     def test_find_best_usb_interface_inactive_fallback(
-        self,
-        sample_network_config,
-        usb_interface_inactive,
-        protected_interface
+        self, sample_network_config, usb_interface_inactive, protected_interface
     ):
         """Test falling back to inactive USB if no active ones"""
         mock_detector = MagicMock()
-        mock_detector.detect_interfaces.return_value = [
-            protected_interface,
-            usb_interface_inactive
-        ]
+        mock_detector.detect_interfaces.return_value = [protected_interface, usb_interface_inactive]
 
-        configurator = USBNICConfigurator(
-            sample_network_config,
-            detector=mock_detector
-        )
+        configurator = USBNICConfigurator(sample_network_config, detector=mock_detector)
 
         interface = configurator.find_best_usb_interface()
         assert interface == usb_interface_inactive
 
-    def test_find_best_usb_interface_none_found(
-        self,
-        sample_network_config,
-        protected_interface
-    ):
+    def test_find_best_usb_interface_none_found(self, sample_network_config, protected_interface):
         """Test when no USB interfaces found"""
         mock_detector = MagicMock()
         mock_detector.detect_interfaces.return_value = [protected_interface]
 
-        configurator = USBNICConfigurator(
-            sample_network_config,
-            detector=mock_detector
-        )
+        configurator = USBNICConfigurator(sample_network_config, detector=mock_detector)
 
         interface = configurator.find_best_usb_interface()
         assert interface is None
 
-    def test_confirm_configuration_dry_run(
-        self,
-        sample_network_config,
-        usb_interface_active
-    ):
+    def test_confirm_configuration_dry_run(self, sample_network_config, usb_interface_active):
         """Test confirmation in dry-run mode (auto-confirm)"""
         configurator = USBNICConfigurator(sample_network_config, dry_run=True)
         assert configurator.confirm_configuration(usb_interface_active)
 
-    def test_confirm_configuration_protected_interface(
-        self,
-        sample_network_config,
-        protected_interface
-    ):
+    def test_confirm_configuration_protected_interface(self, sample_network_config, protected_interface):
         """Test confirmation rejects protected interface"""
         configurator = USBNICConfigurator(sample_network_config, dry_run=False)
         assert not configurator.confirm_configuration(protected_interface)
 
-    @patch('darwin_mgmt_nic.configurator.Confirm.ask', return_value=True)
-    def test_confirm_configuration_user_accepts(
-        self,
-        mock_confirm,
-        sample_network_config,
-        usb_interface_active
-    ):
+    @patch("darwin_mgmt_nic.configurator.Confirm.ask", return_value=True)
+    def test_confirm_configuration_user_accepts(self, mock_confirm, sample_network_config, usb_interface_active):
         """Test user accepts configuration"""
         configurator = USBNICConfigurator(sample_network_config, dry_run=False)
         assert configurator.confirm_configuration(usb_interface_active)
@@ -119,25 +76,15 @@ class TestUSBNICConfigurator:
             console=ANY,
         )
 
-    @patch('darwin_mgmt_nic.configurator.Confirm.ask', return_value=False)
-    def test_confirm_configuration_user_rejects(
-        self,
-        mock_confirm,
-        sample_network_config,
-        usb_interface_active
-    ):
+    @patch("darwin_mgmt_nic.configurator.Confirm.ask", return_value=False)
+    def test_confirm_configuration_user_rejects(self, mock_confirm, sample_network_config, usb_interface_active):
         """Test user rejects configuration"""
         configurator = USBNICConfigurator(sample_network_config, dry_run=False)
         assert not configurator.confirm_configuration(usb_interface_active)
         mock_confirm.assert_called_once()
 
-    @patch('darwin_mgmt_nic.configurator.Confirm.ask', return_value=True)
-    def test_confirm_configuration_uses_rich_confirm(
-        self,
-        mock_confirm,
-        sample_network_config,
-        usb_interface_active
-    ):
+    @patch("darwin_mgmt_nic.configurator.Confirm.ask", return_value=True)
+    def test_confirm_configuration_uses_rich_confirm(self, mock_confirm, sample_network_config, usb_interface_active):
         """Test configurator delegates interactive confirmation to Rich."""
         configurator = USBNICConfigurator(sample_network_config, dry_run=False)
         assert configurator.confirm_configuration(usb_interface_active)
@@ -151,8 +98,12 @@ class TestUSBNICConfigurator:
         configurator = USBNICConfigurator(
             sample_network_config,
             dry_run=True,
-            detector=mock_detector
+            detector=mock_detector,
+            preserve_wifi=True,
         )
+        configurator.service_order_manager = MagicMock()
+        configurator.wifi_monitor = MagicMock()
+        configurator.route_manager = MagicMock()
 
         result = configurator.configure()
         assert result is True
@@ -160,25 +111,39 @@ class TestUSBNICConfigurator:
         # Verify no actual configuration was called
         mock_detector.configure_interface.assert_not_called()
         mock_detector.add_static_route.assert_not_called()
+        configurator.service_order_manager.prevent_usb_priority_takeover.assert_not_called()
+        configurator.service_order_manager.backup_service_order.assert_not_called()
+        configurator.service_order_manager.set_wifi_priority.assert_not_called()
+        configurator.wifi_monitor.get_wifi_status.assert_not_called()
+        configurator.route_manager.add_management_route.assert_not_called()
 
-    @patch('darwin_mgmt_nic.configurator.Confirm.ask', return_value=True)
-    def test_configure_success(
-        self,
-        mock_confirm,
-        sample_network_config,
-        usb_interface_active
-    ):
+    def test_configure_dry_run_without_usb_does_not_preserve_wifi(self, sample_network_config):
+        """Dry-run must not mutate service order even when no USB NIC is present."""
+        mock_detector = MagicMock()
+        mock_detector.detect_interfaces.return_value = []
+
+        configurator = USBNICConfigurator(
+            sample_network_config,
+            dry_run=True,
+            detector=mock_detector,
+            preserve_wifi=True,
+        )
+        configurator.service_order_manager = MagicMock()
+
+        assert configurator.configure() is False
+        configurator.service_order_manager.prevent_usb_priority_takeover.assert_not_called()
+        configurator.service_order_manager.backup_service_order.assert_not_called()
+        configurator.service_order_manager.set_wifi_priority.assert_not_called()
+
+    @patch("darwin_mgmt_nic.configurator.Confirm.ask", return_value=True)
+    def test_configure_success(self, mock_confirm, sample_network_config, usb_interface_active):
         """Test successful configuration"""
         mock_detector = MagicMock()
         mock_detector.detect_interfaces.return_value = [usb_interface_active]
         mock_detector.configure_interface.return_value = True
         mock_detector.test_connectivity.return_value = True
 
-        configurator = USBNICConfigurator(
-            sample_network_config,
-            dry_run=False,
-            detector=mock_detector
-        )
+        configurator = USBNICConfigurator(sample_network_config, dry_run=False, detector=mock_detector)
         configurator.route_manager = MagicMock()
 
         result = configurator.configure()
@@ -193,23 +158,14 @@ class TestUSBNICConfigurator:
         )
         mock_confirm.assert_called_once()
 
-    @patch('darwin_mgmt_nic.configurator.Confirm.ask', return_value=True)
-    def test_configure_failure(
-        self,
-        mock_confirm,
-        sample_network_config,
-        usb_interface_active
-    ):
+    @patch("darwin_mgmt_nic.configurator.Confirm.ask", return_value=True)
+    def test_configure_failure(self, mock_confirm, sample_network_config, usb_interface_active):
         """Test failed configuration"""
         mock_detector = MagicMock()
         mock_detector.detect_interfaces.return_value = [usb_interface_active]
         mock_detector.configure_interface.return_value = False
 
-        configurator = USBNICConfigurator(
-            sample_network_config,
-            dry_run=False,
-            detector=mock_detector
-        )
+        configurator = USBNICConfigurator(sample_network_config, dry_run=False, detector=mock_detector)
         configurator.route_manager = MagicMock()
 
         result = configurator.configure()

--- a/tests/test_detectors.py
+++ b/tests/test_detectors.py
@@ -3,6 +3,7 @@ Tests for base detector functionality
 """
 
 import pytest
+
 from darwin_mgmt_nic.detectors import USBNICDetector
 from darwin_mgmt_nic.macos import MacOSUSBNICDetector
 
@@ -51,6 +52,7 @@ class TestUSBNICDetectorBase:
     def test_multiple_platforms_share_protected_list(self):
         """Test protected interfaces are shared across platforms"""
         from darwin_mgmt_nic.linux import LinuxUSBNICDetector
+
         macos_detector = MacOSUSBNICDetector()
         linux_detector = LinuxUSBNICDetector()
 

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -1,6 +1,5 @@
 from pathlib import Path
 
-
 REPO_ROOT = Path(__file__).parent.parent
 
 
@@ -14,8 +13,13 @@ def test_project_metadata_points_at_github_repository():
 def test_operator_docs_do_not_point_at_retired_gitlab_repository():
     docs = [
         REPO_ROOT / "README.md",
+        REPO_ROOT / "docs" / "artifacts.md",
+        REPO_ROOT / "docs" / "bastion.md",
+        REPO_ROOT / "docs" / "cli.md",
         REPO_ROOT / "docs" / "development.md",
+        REPO_ROOT / "docs" / "index.md",
         REPO_ROOT / "docs" / "quickstart.md",
+        REPO_ROOT / "docs" / "llms.txt",
         REPO_ROOT / "mkdocs.yml",
     ]
 
@@ -49,3 +53,71 @@ def test_agents_file_keeps_crs_policy_out_of_darwin_tool():
     assert "Use the `github` remote" in agents
     assert "crs309-main" not in agents
     assert "vault_mikrotik_password" not in agents
+
+
+def test_bastion_docs_keep_device_specific_policy_out_of_darwin_tool():
+    bastion = (REPO_ROOT / "docs" / "bastion.md").read_text()
+    llms = (REPO_ROOT / "docs" / "llms.txt").read_text()
+
+    assert "tailnet -> bastion host -> USB OOB NIC -> managed network device" in bastion
+    assert "darwin-nic configure --profile homelab --preserve-wifi" in bastion
+    assert "Device-specific hostnames" in bastion
+    assert "Device-specific topology" in llms
+    assert "crs309-main" not in bastion
+    assert "vault_mikrotik_password" not in bastion
+    assert "crs309-main" not in llms
+    assert "vault_mikrotik_password" not in llms
+
+
+def test_public_docs_stay_generic_and_release_accurate():
+    public_docs = [
+        REPO_ROOT / "README.md",
+        REPO_ROOT / "docs" / "artifacts.md",
+        REPO_ROOT / "docs" / "cli.md",
+        REPO_ROOT / "docs" / "development.md",
+        REPO_ROOT / "docs" / "index.md",
+        REPO_ROOT / "docs" / "quickstart.md",
+        REPO_ROOT / "docs" / "superpowers" / "release-sprint-plan.md",
+        REPO_ROOT / "examples" / "config.toml",
+        REPO_ROOT / "nix" / "modules" / "home-manager.nix",
+    ]
+    combined = "\n".join(path.read_text() for path in public_docs)
+
+    stale_or_too_specific = [
+        "random networky",
+        "yucky fruit",
+        "os noes",
+        "CRS309 Bastion",
+        "tinyland darwin pkg artifactory",
+        "Single Binary",
+        "No Python environment required",
+        "GitLab CI only",
+        "76 passing tests",
+        "21 percent",
+        "CRS310 Secondary",
+        "BiDi backhaul",
+    ]
+
+    for phrase in stale_or_too_specific:
+        assert phrase not in combined
+
+
+def test_artifacts_docs_match_current_release_policy():
+    artifacts = (REPO_ROOT / "docs" / "artifacts.md").read_text()
+    readme = (REPO_ROOT / "README.md").read_text()
+
+    assert "wheel/source distributions" in artifacts
+    assert "Nix packages" in artifacts
+    assert "Standalone binary" in artifacts
+    assert "not validated yet" in artifacts
+    assert "Homebrew | Not shipped" in artifacts
+    assert "PyPI publishing and standalone binary distribution remain tracked release" in readme
+
+
+def test_example_profile_networks_are_internally_consistent():
+    example = (REPO_ROOT / "examples" / "config.toml").read_text()
+
+    assert 'device_ip = "192.168.88.1"' in example
+    assert 'laptop_ip = "192.168.88.100"' in example
+    assert 'mgmt_network = "192.168.88.0/24"' in example
+    assert 'mgmt_network = "192.168.10.0/24"' not in example

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -2,33 +2,34 @@
 Tests for factory pattern
 """
 
-import pytest
 from unittest.mock import patch
 
-from darwin_mgmt_nic.factory import USBNICDetectorFactory
+import pytest
+
 from darwin_mgmt_nic.config import OSType
-from darwin_mgmt_nic.macos import MacOSUSBNICDetector
+from darwin_mgmt_nic.factory import USBNICDetectorFactory
 from darwin_mgmt_nic.linux import LinuxUSBNICDetector
+from darwin_mgmt_nic.macos import MacOSUSBNICDetector
 
 
 class TestUSBNICDetectorFactory:
     """Test factory pattern implementation"""
 
-    @patch('platform.system')
+    @patch("platform.system")
     def test_create_macos_detector(self, mock_system):
         """Test factory creates macOS detector"""
         mock_system.return_value = "Darwin"
         detector = USBNICDetectorFactory.create()
         assert isinstance(detector, MacOSUSBNICDetector)
 
-    @patch('platform.system')
+    @patch("platform.system")
     def test_create_linux_detector(self, mock_system):
         """Test factory creates Linux detector"""
         mock_system.return_value = "Linux"
         detector = USBNICDetectorFactory.create()
         assert isinstance(detector, LinuxUSBNICDetector)
 
-    @patch('platform.system')
+    @patch("platform.system")
     def test_create_unsupported_os(self, mock_system):
         """Test factory raises error for unsupported OS"""
         mock_system.return_value = "FreeBSD"
@@ -55,20 +56,20 @@ class TestUSBNICDetectorFactory:
         with pytest.raises(NotImplementedError, match="Windows support"):
             USBNICDetectorFactory.create(OSType.WINDOWS)
 
-    @patch('platform.system')
+    @patch("platform.system")
     def test_is_supported_macos(self, mock_system):
         """Test macOS is supported"""
         mock_system.return_value = "Darwin"
         assert USBNICDetectorFactory.is_supported()
 
-    @patch('platform.system')
+    @patch("platform.system")
     def test_is_supported_linux(self, mock_system):
         """Test Linux is marked as supported (even if experimental)"""
         mock_system.return_value = "Linux"
         # Currently only macOS is fully supported
         assert not USBNICDetectorFactory.is_supported()
 
-    @patch('platform.system')
+    @patch("platform.system")
     def test_is_supported_unknown_os(self, mock_system):
         """Test unknown OS is not supported"""
         mock_system.return_value = "FreeBSD"
@@ -76,18 +77,18 @@ class TestUSBNICDetectorFactory:
 
     def test_detect_os_macos(self):
         """Test OS detection for macOS"""
-        with patch('platform.system', return_value="Darwin"):
+        with patch("platform.system", return_value="Darwin"):
             os_type = USBNICDetectorFactory._detect_os()
             assert os_type == OSType.MACOS
 
     def test_detect_os_linux(self):
         """Test OS detection for Linux"""
-        with patch('platform.system', return_value="Linux"):
+        with patch("platform.system", return_value="Linux"):
             os_type = USBNICDetectorFactory._detect_os()
-            assert OSType.LINUX
+            assert os_type == OSType.LINUX
 
     def test_detect_os_windows(self):
         """Test OS detection for Windows"""
-        with patch('platform.system', return_value="Windows"):
+        with patch("platform.system", return_value="Windows"):
             os_type = USBNICDetectorFactory._detect_os()
             assert os_type == OSType.WINDOWS

--- a/tests/test_linux.py
+++ b/tests/test_linux.py
@@ -1,0 +1,92 @@
+"""
+Tests for the Linux detector placeholder.
+"""
+
+import subprocess
+
+from darwin_mgmt_nic.linux import LinuxUSBNICDetector
+
+
+class FakeCarrierPath:
+    """Path-like test double for Linux carrier files."""
+
+    def __init__(self, value="1", *, exists=True, raises=False):
+        self.value = value
+        self._exists = exists
+        self.raises = raises
+
+    def exists(self):
+        return self._exists
+
+    def read_text(self):
+        if self.raises:
+            raise OSError("carrier unavailable")
+        return self.value
+
+
+def test_detect_interfaces_placeholder_returns_empty_list():
+    detector = LinuxUSBNICDetector()
+
+    assert detector.detect_interfaces() == []
+
+
+def test_get_interface_status_reads_carrier(monkeypatch):
+    detector = LinuxUSBNICDetector()
+    monkeypatch.setattr("darwin_mgmt_nic.linux.Path", lambda path: FakeCarrierPath("1\n"))
+
+    assert detector.get_interface_status("eth0") is True
+
+    monkeypatch.setattr("darwin_mgmt_nic.linux.Path", lambda path: FakeCarrierPath("0\n"))
+
+    assert detector.get_interface_status("eth0") is False
+
+
+def test_get_interface_status_handles_missing_or_unreadable_carrier(monkeypatch):
+    detector = LinuxUSBNICDetector()
+    monkeypatch.setattr("darwin_mgmt_nic.linux.Path", lambda path: FakeCarrierPath(exists=False))
+
+    assert detector.get_interface_status("eth0") is False
+
+    monkeypatch.setattr("darwin_mgmt_nic.linux.Path", lambda path: FakeCarrierPath(raises=True))
+
+    assert detector.get_interface_status("eth0") is False
+
+
+def test_configure_and_route_placeholders_fail_closed():
+    detector = LinuxUSBNICDetector()
+
+    assert detector.configure_interface("eth0", "192.0.2.100", "255.255.255.0") is False
+    assert detector.add_static_route("198.51.100.0/24", "192.0.2.1") is False
+
+
+def test_test_connectivity_uses_ping_result(monkeypatch):
+    detector = LinuxUSBNICDetector()
+    commands = []
+
+    def fake_run(cmd, **kwargs):
+        commands.append((cmd, kwargs))
+        return subprocess.CompletedProcess(cmd, 0)
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+
+    assert detector.test_connectivity("192.0.2.1", count=2, timeout=4) is True
+    assert commands == [
+        (
+            ["ping", "-c", "2", "-W", "4", "192.0.2.1"],
+            {"capture_output": True, "timeout": 13},
+        )
+    ]
+
+
+def test_test_connectivity_handles_ping_failure_and_exception(monkeypatch):
+    detector = LinuxUSBNICDetector()
+    monkeypatch.setattr("subprocess.run", lambda *args, **kwargs: subprocess.CompletedProcess(args[0], 1))
+
+    assert detector.test_connectivity("192.0.2.1") is False
+
+    def raise_os_error(*args, **kwargs):
+        raise OSError("ping missing")
+
+    monkeypatch.setattr("subprocess.run", raise_os_error)
+
+    assert detector.test_connectivity("192.0.2.1") is False

--- a/tests/test_macos.py
+++ b/tests/test_macos.py
@@ -2,8 +2,10 @@
 Tests for macOS-specific implementation
 """
 
-import pytest
 from unittest.mock import MagicMock, patch
+
+import pytest
+
 from darwin_mgmt_nic.config import NetworkInterface
 from darwin_mgmt_nic.macos import MacOSUSBNICDetector
 
@@ -59,65 +61,50 @@ class TestMacOSUSBNICDetector:
         vendor = detector._extract_vendor("Unknown Network Device")
         assert vendor is None
 
-    @patch('subprocess.run')
+    @patch("subprocess.run")
     def test_get_interface_ip(self, mock_run):
         """Test getting interface IP address"""
-        mock_run.return_value = MagicMock(
-            returncode=0,
-            stdout="inet 192.0.2.100 netmask 0xffffff00"
-        )
+        mock_run.return_value = MagicMock(returncode=0, stdout="inet 192.0.2.100 netmask 0xffffff00")
 
         detector = MacOSUSBNICDetector()
         ip = detector._get_interface_ip("en7")
         assert ip == "192.0.2.100"
 
-    @patch('subprocess.run')
+    @patch("subprocess.run")
     def test_get_interface_ip_no_ip(self, mock_run):
         """Test interface with no IP"""
-        mock_run.return_value = MagicMock(
-            returncode=0,
-            stdout="ether 11:22:33:44:55:66\nstatus: active"
-        )
+        mock_run.return_value = MagicMock(returncode=0, stdout="ether 11:22:33:44:55:66\nstatus: active")
 
         detector = MacOSUSBNICDetector()
         ip = detector._get_interface_ip("en7")
         assert ip is None
 
-    @patch('subprocess.run')
+    @patch("subprocess.run")
     def test_get_mac_address(self, mock_run):
         """Test getting MAC address"""
-        mock_run.return_value = MagicMock(
-            returncode=0,
-            stdout="ether 11:22:33:44:55:66"
-        )
+        mock_run.return_value = MagicMock(returncode=0, stdout="ether 11:22:33:44:55:66")
 
         detector = MacOSUSBNICDetector()
         mac = detector._get_mac_address("en7")
         assert mac == "11:22:33:44:55:66"
 
-    @patch('subprocess.run')
+    @patch("subprocess.run")
     def test_get_interface_status_active(self, mock_run):
         """Test checking active interface"""
-        mock_run.return_value = MagicMock(
-            returncode=0,
-            stdout="status: active"
-        )
+        mock_run.return_value = MagicMock(returncode=0, stdout="status: active")
 
         detector = MacOSUSBNICDetector()
         assert detector.get_interface_status("en7")
 
-    @patch('subprocess.run')
+    @patch("subprocess.run")
     def test_get_interface_status_inactive(self, mock_run):
         """Test checking inactive interface"""
-        mock_run.return_value = MagicMock(
-            returncode=0,
-            stdout="status: inactive"
-        )
+        mock_run.return_value = MagicMock(returncode=0, stdout="status: inactive")
 
         detector = MacOSUSBNICDetector()
         assert not detector.get_interface_status("en7")
 
-    @patch('subprocess.run')
+    @patch("subprocess.run")
     def test_configure_interface_protected(self, mock_run):
         """Test configuring protected interface raises error"""
         detector = MacOSUSBNICDetector()
@@ -181,6 +168,7 @@ class TestMacOSUSBNICDetector:
     @patch("subprocess.run")
     def test_get_bastion_diagnostics_detects_nwi_necp_and_tailscale(self, mock_run):
         """Bastion diagnostics should surface the same host-side symptoms we saw on pzm."""
+
         def run_side_effect(cmd, *args, **kwargs):
             if cmd[:2] == ["scutil", "--nwi"]:
                 return MagicMock(
@@ -239,19 +227,16 @@ class TestMacOSUSBNICDetector:
         assert diagnostics.tailscale_extension_active is True
         assert diagnostics.recent_necp_drop is True
 
-    @patch('subprocess.run')
+    @patch("subprocess.run")
     def test_add_static_route_already_exists(self, mock_run):
         """Test adding route that already exists"""
-        mock_run.return_value = MagicMock(
-            returncode=0,
-            stdout="198.51.100.0/24        192.0.2.1       UGSc"
-        )
+        mock_run.return_value = MagicMock(returncode=0, stdout="198.51.100.0/24        192.0.2.1       UGSc")
 
         detector = MacOSUSBNICDetector()
         result = detector.add_static_route("198.51.100.0/24", "192.0.2.1")
         assert result is True
 
-    @patch('subprocess.run')
+    @patch("subprocess.run")
     def test_test_connectivity_success(self, mock_run):
         """Test successful connectivity test"""
         mock_run.return_value = MagicMock(returncode=0)
@@ -259,7 +244,7 @@ class TestMacOSUSBNICDetector:
         detector = MacOSUSBNICDetector()
         assert detector.test_connectivity("192.0.2.1")
 
-    @patch('subprocess.run')
+    @patch("subprocess.run")
     def test_test_connectivity_failure(self, mock_run):
         """Test failed connectivity test"""
         mock_run.return_value = MagicMock(returncode=1)

--- a/tests/test_network_manager.py
+++ b/tests/test_network_manager.py
@@ -1,0 +1,502 @@
+"""
+Tests for network manager parsing, scoring, and safety helpers.
+"""
+
+import subprocess
+
+from darwin_mgmt_nic.config import NetworkInterface
+from darwin_mgmt_nic.network_manager import (
+    CableQualityInfo,
+    HardwareAnalyzer,
+    HardwareInfo,
+    InterfaceScorer,
+    InterferenceAssessor,
+    NetworkDashboard,
+    PortInfo,
+    RouteManager,
+    ServiceOrderManager,
+    WiFiMetrics,
+    WiFiMonitor,
+    WiFiStatus,
+)
+
+SERVICE_ORDER_OUTPUT = """
+An asterisk (*) denotes that a network service is disabled.
+(1) USB Management
+(Hardware Port: USB 10/100/1000 LAN, Device: en7)
+(2) Wi-Fi
+(Hardware Port: Wi-Fi, Device: en0)
+(3) Thunderbolt Bridge
+(Hardware Port: Thunderbolt Bridge, Device: bridge0)
+"""
+
+
+def completed(cmd, returncode=0, stdout="", stderr=""):
+    return subprocess.CompletedProcess(cmd, returncode, stdout=stdout, stderr=stderr)
+
+
+class FakeConsole:
+    """Rich console test double."""
+
+    instances = []
+
+    def __init__(self):
+        self.printed = []
+        self.__class__.instances.append(self)
+
+    def print(self, *objects, **kwargs):
+        self.printed.append(objects)
+
+
+class TestServiceOrderManager:
+    """Test macOS service-order parsing and safety logic."""
+
+    def test_backup_and_get_current_service_order_parse_networksetup_output(self, monkeypatch):
+        commands = []
+
+        def fake_run(cmd, **kwargs):
+            commands.append(cmd)
+            return completed(cmd, stdout=SERVICE_ORDER_OUTPUT)
+
+        monkeypatch.setattr("darwin_mgmt_nic.network_manager.subprocess.run", fake_run)
+        manager = ServiceOrderManager(timeout=3)
+
+        assert manager.backup_service_order() == ["USB Management", "Wi-Fi", "Thunderbolt Bridge"]
+        assert manager.get_current_service_order() == ["USB Management", "Wi-Fi", "Thunderbolt Bridge"]
+        assert commands == [
+            ["networksetup", "-listnetworkserviceorder"],
+            ["networksetup", "-listnetworkserviceorder"],
+        ]
+
+    def test_backup_service_order_handles_command_failure_and_timeout(self, monkeypatch):
+        manager = ServiceOrderManager()
+        monkeypatch.setattr(
+            "darwin_mgmt_nic.network_manager.subprocess.run",
+            lambda cmd, **kwargs: completed(cmd, returncode=1, stderr="nope"),
+        )
+
+        assert manager.backup_service_order() == []
+
+        def raise_timeout(cmd, **kwargs):
+            raise subprocess.TimeoutExpired(cmd, 10)
+
+        monkeypatch.setattr("darwin_mgmt_nic.network_manager.subprocess.run", raise_timeout)
+
+        assert manager.backup_service_order() == []
+
+    def test_restore_service_order_requires_backup_and_applies_order(self, monkeypatch):
+        manager = ServiceOrderManager()
+
+        assert manager.restore_service_order() is False
+
+        calls = []
+        manager._backup_order = ["Wi-Fi", "Thunderbolt Bridge", "USB Management"]
+
+        def fake_run(cmd, **kwargs):
+            calls.append(cmd)
+            return completed(cmd)
+
+        monkeypatch.setattr("darwin_mgmt_nic.network_manager.subprocess.run", fake_run)
+
+        assert manager.restore_service_order() is True
+        assert calls == [["networksetup", "-ordernetworkservices", "Wi-Fi", "Thunderbolt Bridge", "USB Management"]]
+
+    def test_find_wifi_service_matches_common_names(self):
+        manager = ServiceOrderManager()
+
+        assert manager._find_wifi_service(["Ethernet", "Wi-Fi"]) == "Wi-Fi"
+        assert manager._find_wifi_service(["Airport", "Ethernet"]) == "Airport"
+        assert manager._find_wifi_service(["USB LAN"]) is None
+
+    def test_set_wifi_priority_moves_wifi_to_front(self, monkeypatch):
+        manager = ServiceOrderManager()
+        monkeypatch.setattr(manager, "_get_current_service_order", lambda: ["USB Management", "Wi-Fi", "VPN"])
+        calls = []
+
+        def fake_run(cmd, **kwargs):
+            calls.append(cmd)
+            return completed(cmd)
+
+        monkeypatch.setattr("darwin_mgmt_nic.network_manager.subprocess.run", fake_run)
+
+        assert manager.set_wifi_priority() is True
+        assert calls == [["networksetup", "-ordernetworkservices", "Wi-Fi", "USB Management", "VPN"]]
+
+    def test_validate_service_order_rejects_empty_or_poor_wifi_position(self, monkeypatch):
+        manager = ServiceOrderManager()
+        monkeypatch.setattr(manager, "_get_current_service_order", lambda: [])
+        assert manager.validate_service_order() is False
+
+        monkeypatch.setattr(manager, "_get_current_service_order", lambda: ["USB", "VPN", "Bridge", "LAN", "Wi-Fi"])
+        assert manager.validate_service_order() is False
+
+        monkeypatch.setattr(manager, "_get_current_service_order", lambda: ["Wi-Fi", "USB", "VPN", "Bridge"])
+        assert manager.validate_service_order() is True
+
+    def test_prevent_usb_priority_takeover_reorders_wifi_first_usb_last(self, monkeypatch):
+        manager = ServiceOrderManager()
+        monkeypatch.setattr(manager, "_get_current_service_order", lambda: ["USB Ethernet", "VPN", "Wi-Fi", "LAN"])
+        calls = []
+
+        def fake_run(cmd, **kwargs):
+            calls.append(cmd)
+            return completed(cmd)
+
+        monkeypatch.setattr("darwin_mgmt_nic.network_manager.subprocess.run", fake_run)
+
+        assert manager.prevent_usb_priority_takeover() is True
+        assert calls == [["networksetup", "-ordernetworkservices", "Wi-Fi", "VPN", "USB Ethernet", "LAN"]]
+
+    def test_prevent_usb_priority_takeover_noops_when_wifi_already_first(self, monkeypatch):
+        manager = ServiceOrderManager()
+        monkeypatch.setattr(manager, "_get_current_service_order", lambda: ["Wi-Fi", "USB Ethernet"])
+
+        assert manager.prevent_usb_priority_takeover() is True
+
+
+class TestWiFiMonitor:
+    """Test Wi-Fi parsing and metric helpers."""
+
+    def test_find_airport_command_returns_first_existing_path(self, monkeypatch):
+        calls = []
+
+        def fake_run(cmd, **kwargs):
+            calls.append(cmd)
+            return completed(cmd, returncode=0 if "Current/Resources/airport" in cmd[-1] else 1)
+
+        monkeypatch.setattr("darwin_mgmt_nic.network_manager.subprocess.run", fake_run)
+
+        monitor = WiFiMonitor()
+
+        assert monitor._airport_path.endswith("Current/Resources/airport")
+
+    def test_parse_airport_output_builds_metrics(self, monkeypatch):
+        monitor = WiFiMonitor.__new__(WiFiMonitor)
+        monitor.timeout = 10
+        monkeypatch.setattr(monitor, "detect_interference", lambda: False)
+
+        metrics = monitor._parse_airport_output(
+            """
+            agrCtlRSSI: -55
+            agrCtlNoise: -92
+            lastTxRate: 144.0
+            SSID: labwifi
+            BSSID: aa:bb:cc:dd:ee:ff
+            channel: 149,1
+            """
+        )
+
+        assert metrics.status == WiFiStatus.CONNECTED
+        assert metrics.signal_strength == -55
+        assert metrics.noise_level == -92
+        assert metrics.snr == 37
+        assert metrics.transmit_rate == 144.0
+        assert metrics.ssid == "labwifi"
+        assert metrics.band == "5GHz"
+
+    def test_parse_airport_output_marks_degraded_and_24ghz(self, monkeypatch):
+        monitor = WiFiMonitor.__new__(WiFiMonitor)
+        monitor.timeout = 10
+        monkeypatch.setattr(monitor, "detect_interference", lambda: False)
+
+        metrics = monitor._parse_airport_output(
+            """
+            agrCtlRSSI: -80
+            agrCtlNoise: -90
+            lastTxRate: 8
+            SSID: slowwifi
+            channel: 6
+            """
+        )
+
+        assert metrics.status == WiFiStatus.DEGRADED
+        assert metrics.snr == 10
+        assert metrics.band == "2.4GHz"
+
+    def test_get_wifi_status_handles_missing_command_failure_timeout_and_success(self, monkeypatch):
+        monitor = WiFiMonitor.__new__(WiFiMonitor)
+        monitor.timeout = 10
+        monitor.logger = WiFiMonitor().logger
+        monitor._airport_path = None
+        assert monitor.get_wifi_status() is None
+
+        monitor._airport_path = "/airport"
+        monkeypatch.setattr(
+            "darwin_mgmt_nic.network_manager.subprocess.run",
+            lambda cmd, **kwargs: completed(cmd, returncode=1),
+        )
+        disconnected = monitor.get_wifi_status()
+        assert disconnected.status == WiFiStatus.DISCONNECTED
+
+        monkeypatch.setattr(monitor, "_parse_airport_output", lambda output: "parsed")
+        monkeypatch.setattr(
+            "darwin_mgmt_nic.network_manager.subprocess.run",
+            lambda cmd, **kwargs: completed(cmd, stdout="airport output"),
+        )
+        assert monitor.get_wifi_status() == "parsed"
+
+    def test_connectivity_and_details_helpers(self, monkeypatch):
+        monitor = WiFiMonitor.__new__(WiFiMonitor)
+        monitor.timeout = 10
+        monitor.logger = WiFiMonitor().logger
+        monkeypatch.setattr(
+            "darwin_mgmt_nic.network_manager.subprocess.run",
+            lambda cmd, **kwargs: completed(cmd, returncode=0),
+        )
+        assert monitor.check_connectivity("1.1.1.1", count=1) is True
+
+        metrics = WiFiMetrics(
+            status=WiFiStatus.CONNECTED,
+            signal_strength=-55,
+            noise_level=-92,
+            snr=37,
+            transmit_rate=144,
+            connection_uptime=0,
+            ssid="labwifi",
+            bssid="aa:bb:cc:dd:ee:ff",
+            channel=149,
+            band="5GHz",
+        )
+        monkeypatch.setattr(monitor, "get_wifi_status", lambda: metrics)
+        details = monitor.get_connection_details()
+
+        assert details["status"] == "connected"
+        assert details["ssid"] == "labwifi"
+        assert details["signal_strength"] == "-55 dBm"
+        assert monitor.detect_interference() is False
+
+        degraded = WiFiMetrics(
+            status=WiFiStatus.DEGRADED,
+            signal_strength=-80,
+            noise_level=-70,
+            snr=10,
+            transmit_rate=4,
+            connection_uptime=0,
+            ssid="badwifi",
+            bssid="",
+            channel=6,
+            band="2.4GHz",
+        )
+        monkeypatch.setattr(monitor, "get_wifi_status", lambda: degraded)
+        assert monitor.detect_interference() is True
+
+        monkeypatch.setattr(monitor, "get_wifi_status", lambda: None)
+        assert monitor.get_connection_details() == {"status": "disconnected"}
+
+
+class TestInterfaceScorer:
+    """Test interface scoring and ranking."""
+
+    def test_scores_and_ranks_interfaces(self):
+        wifi_metrics = WiFiMetrics(
+            status=WiFiStatus.CONNECTED,
+            signal_strength=-50,
+            noise_level=-90,
+            snr=40,
+            transmit_rate=300,
+            connection_uptime=0,
+            ssid="labwifi",
+            bssid="",
+            channel=149,
+            band="5GHz",
+        )
+
+        class FakeWiFiMonitor:
+            def get_wifi_status(self):
+                return wifi_metrics
+
+            def check_connectivity(self):
+                return True
+
+        class FakeInterferenceAssessor:
+            def assess_usb_interference_risk(self, interface):
+                return 70.0 if interface == "en7" else 0.0
+
+        scorer = InterfaceScorer(FakeWiFiMonitor(), FakeInterferenceAssessor())
+        wifi = NetworkInterface("en0", "Wi-Fi", is_usb=False, is_wifi=True, is_active=True, is_protected=True)
+        usb = NetworkInterface("en7", "USB Ethernet", is_usb=True, is_active=True)
+        inactive = NetworkInterface("en9", "USB Ethernet", is_usb=True, is_active=False)
+
+        ranked = scorer.rank_interfaces([usb, wifi, inactive])
+
+        assert ranked[0].interface_name == "en0"
+        assert scorer.assess_wifi_preference(wifi) == 90.0
+        assert scorer.assess_wifi_preference(usb) == 20.0
+        assert scorer.evaluate_interference_risk("en7") == 70.0
+        assert scorer._evaluate_capabilities(wifi) == 95.0
+        assert scorer._evaluate_reliability(inactive) == 30.0
+
+
+class TestRouteManager:
+    """Test route management helpers."""
+
+    def test_add_management_route_success_and_existing_route(self, monkeypatch):
+        calls = []
+
+        def fake_run(cmd, **kwargs):
+            calls.append(cmd)
+            if cmd[0] == "route":
+                return completed(cmd, returncode=1, stderr="exists")
+            return completed(cmd, stdout="198.51.100.0/24 192.0.2.1 UGSc en7")
+
+        monkeypatch.setattr("darwin_mgmt_nic.network_manager.subprocess.run", fake_run)
+        manager = RouteManager()
+
+        assert manager.add_management_route("198.51.100.0/24", "en7", "192.0.2.1") is True
+        assert calls[0] == ["route", "add", "-net", "198.51.100.0/24", "192.0.2.1"]
+
+    def test_add_management_route_failure_and_host_route_normalization(self, monkeypatch):
+        calls = []
+
+        def fake_run(cmd, **kwargs):
+            calls.append(cmd)
+            return completed(cmd, returncode=1, stderr="failed")
+
+        monkeypatch.setattr("darwin_mgmt_nic.network_manager.subprocess.run", fake_run)
+        manager = RouteManager()
+
+        assert manager.add_management_route("192.0.2.1", "en7", "192.0.2.100") is False
+        assert calls[0] == ["route", "add", "-net", "192.0.2.1/32", "192.0.2.100"]
+
+    def test_preserve_default_gateway_and_validate_routing(self, monkeypatch):
+        monkeypatch.setattr(
+            "darwin_mgmt_nic.network_manager.subprocess.run",
+            lambda cmd, **kwargs: completed(cmd, stdout="default 192.168.1.1 UGSc en0\n"),
+        )
+        manager = RouteManager()
+
+        assert manager.preserve_default_gateway() is True
+        assert manager.validate_routing() is True
+
+        monkeypatch.setattr(
+            "darwin_mgmt_nic.network_manager.subprocess.run",
+            lambda cmd, **kwargs: completed(cmd, stdout=""),
+        )
+        assert manager.preserve_default_gateway() is False
+
+    def test_create_route_table_requires_all_routes_to_succeed(self, monkeypatch):
+        manager = RouteManager()
+        monkeypatch.setattr(
+            manager,
+            "add_management_route",
+            lambda destination, interface, gateway: destination != "bad",
+        )
+
+        assert (
+            manager.create_route_table(
+                [
+                    {"destination": "198.51.100.0/24", "gateway": "192.0.2.1", "interface": "en7"},
+                    {"destination": "bad", "gateway": "192.0.2.1", "interface": "en7"},
+                    {"destination": "missing"},
+                ]
+            )
+            is False
+        )
+
+
+class TestHardwareAndInterferenceHelpers:
+    """Test hardware analysis and interference heuristics."""
+
+    def test_hardware_model_and_port_helpers(self):
+        analyzer = HardwareAnalyzer.__new__(HardwareAnalyzer)
+
+        assert analyzer._parse_model_name("MacBookPro16,1 2020") == ("MacBook Pro", 2020)
+        assert analyzer._parse_model_name("Macmini9,1") == ("Mac mini", 2020)
+        assert analyzer._determine_chassis_type("MacBookAir10,1") == "laptop"
+        assert analyzer._determine_chassis_type("iMac21,1") == "desktop_all_in_one"
+        assert analyzer._get_wifi_antenna_locations("Macmini9,1") == ["rear_panel"]
+        assert analyzer._calculate_wifi_proximity({"location": "rear panel"}, ["rear_panel"]) == 3.0
+        assert analyzer._is_port_recommended_for_management({"type": "USB 2.0"}, 8.0) is False
+        assert analyzer._is_port_recommended_for_management({"type": "Thunderbolt"}, 4.0) is True
+
+        analyzer_with_layout = HardwareAnalyzer.__new__(HardwareAnalyzer)
+        analyzer_with_layout.analyze_port_layout = lambda: []
+        assert analyzer_with_layout.assess_antenna_proximity("unknown") == 5.0
+
+    def test_hardware_recommendations_use_generic_fallback(self, monkeypatch):
+        analyzer = HardwareAnalyzer.__new__(HardwareAnalyzer)
+        analyzer.logger = HardwareAnalyzer().logger
+        analyzer.timeout = 10
+        monkeypatch.setattr(analyzer, "detect_macbook_model", lambda: None)
+
+        ports = analyzer.analyze_port_layout()
+        recs = analyzer.recommend_optimal_setup()
+
+        assert all(isinstance(port, PortInfo) for port in ports)
+        assert recs["macbook_model"] == "Unknown"
+        assert recs["interference_risk"] == 50.0
+
+    def test_interference_quality_and_matching_helpers(self):
+        assessor = InterferenceAssessor.__new__(InterferenceAssessor)
+
+        assert assessor._device_matches_interface({"_name": "Realtek USB LAN"}, "en7") is True
+        assert assessor._device_matches_interface({"_name": "Keyboard"}, "en7") is False
+        assert assessor._determine_usb_version("Up to 480 Mb/s") == "2.0"
+        assert assessor._determine_usb_version("Up to 5 Gb/s") == "3.0"
+        assert assessor._determine_usb_version("Up to 10 Gb/s") == "3.1"
+        assert assessor._assess_shielding({"Vendor_ID": "Apple"}, "2.0") is True
+        assert assessor._assess_ferrite_core({"_name": "Shielded ferrite adapter"}) is True
+        assert assessor._estimate_cable_length({}) == 1.5
+        assert assessor._calculate_quality_score(True, True, 1.5, "3.1") == 95.0
+        assessor._assess_cable_quality = lambda interface: CableQualityInfo(False, False, 1.0, "3.0", 50.0)
+        assert assessor.check_cable_quality_indicators("en7") is False
+
+    def test_interference_risk_and_recommendations(self, monkeypatch):
+        assessor = InterferenceAssessor.__new__(InterferenceAssessor)
+        assessor.logger = InterferenceAssessor().logger
+        hardware = HardwareInfo(
+            model="MacBook Pro",
+            year=2021,
+            model_identifier="MacBookPro18,3",
+            usb_ports=[],
+            wifi_antenna_locations=["display_clamshell"],
+            chassis_type="laptop",
+        )
+        assessor.hardware_analyzer = HardwareAnalyzer.__new__(HardwareAnalyzer)
+        monkeypatch.setattr(assessor.hardware_analyzer, "detect_macbook_model", lambda: hardware)
+        monkeypatch.setattr(assessor.hardware_analyzer, "assess_antenna_proximity", lambda interface: 5.0)
+        monkeypatch.setattr(assessor.hardware_analyzer, "analyze_port_layout", lambda: [])
+        monkeypatch.setattr(
+            assessor,
+            "_assess_cable_quality",
+            lambda interface: CableQualityInfo(False, False, 3.0, "3.0", 40.0),
+        )
+        monkeypatch.setattr(assessor, "_assess_environmental_factors", lambda: 20.0)
+
+        assert assessor.assess_usb_interference_risk("usb-ethernet") == 100
+        assert assessor.assess_usb_interference_risk("en0") == 0.0
+        assert "Recommended ports for MacBook Pro:" in assessor.recommend_port_selection()
+        assert any("MacBook Pro" in strategy for strategy in assessor.suggest_mitigation_strategies())
+
+
+class TestNetworkDashboardHelpers:
+    """Test dashboard status labels and rendering branches."""
+
+    def test_status_label_helpers(self):
+        dashboard = NetworkDashboard.__new__(NetworkDashboard)
+
+        assert dashboard._get_signal_status(-45) == "[green]Excellent[/green]"
+        assert dashboard._get_signal_status(-65) == "[yellow]Fair[/yellow]"
+        assert dashboard._get_noise_status(-91) == "[green]Very Low[/green]"
+        assert dashboard._get_snr_status(10) == "[red]Poor[/red]"
+        assert dashboard._get_rate_status(75) == "[green]Good[/green]"
+
+    def test_panel_helpers_render_missing_and_present_data(self):
+        dashboard = NetworkDashboard.__new__(NetworkDashboard)
+        metrics = WiFiMetrics(
+            status=WiFiStatus.CONNECTED,
+            signal_strength=-55,
+            noise_level=-92,
+            snr=37,
+            transmit_rate=144,
+            connection_uptime=0,
+            ssid="labwifi",
+            bssid="",
+            channel=149,
+            band="5GHz",
+        )
+
+        assert "unavailable" in str(dashboard._create_wifi_panel(None).renderable)
+        assert "labwifi" in str(dashboard._create_wifi_panel(metrics).renderable)
+        assert "unavailable" in str(dashboard._create_service_panel([]).renderable)
+        assert "Wi-Fi" in str(dashboard._create_service_panel(["Wi-Fi", "USB"]).renderable)

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,222 @@
+"""
+Tests for TOML/env settings loading.
+"""
+
+import logging
+
+from darwin_mgmt_nic.settings import NetworkProfile, init_config, load_settings
+
+
+def write_config(path, content: str):
+    path.write_text(content.strip() + "\n")
+    return path
+
+
+class TestNetworkProfile:
+    """Test profile serialization contract used by declarative config generators."""
+
+    def test_to_dict_uses_toml_schema_keys(self):
+        profile = NetworkProfile(
+            device_ip="192.168.88.1",
+            laptop_ip="192.168.88.100",
+            netmask="255.255.255.0",
+            mgmt_network="192.168.88.0/24",
+            device_name="Lab Management Device",
+            description="USB OOB management path",
+            device_type="network",
+        )
+
+        assert profile.to_dict() == {
+            "device_ip": "192.168.88.1",
+            "laptop_ip": "192.168.88.100",
+            "netmask": "255.255.255.0",
+            "mgmt_network": "192.168.88.0/24",
+            "device_name": "Lab Management Device",
+            "description": "USB OOB management path",
+            "device_type": "network",
+        }
+
+
+class TestLoadSettings:
+    """Test config precedence and profile application."""
+
+    def test_load_settings_merges_configs_and_applies_default_profile(self, tmp_path, monkeypatch):
+        base = write_config(
+            tmp_path / "base.toml",
+            """
+            [defaults]
+            device_ip = "192.0.2.1"
+            laptop_ip = "192.0.2.100"
+            netmask = "255.255.255.0"
+            mgmt_network = "198.51.100.0/24"
+            preserve_wifi = false
+
+            [profiles.homelab]
+            device_ip = "198.51.100.1"
+            laptop_ip = "198.51.100.100"
+            device_name = "Base Device"
+            """,
+        )
+        local = write_config(
+            tmp_path / "local.toml",
+            """
+            default_profile = "homelab"
+
+            [defaults]
+            netmask = "255.255.0.0"
+            show_dashboard = true
+
+            [profiles.homelab]
+            device_ip = "192.168.88.1"
+            laptop_ip = "192.168.88.100"
+            mgmt_network = "192.168.88.0/24"
+            device_name = "Lab Management Device"
+            description = "USB OOB management path"
+            device_type = "network"
+            """,
+        )
+        monkeypatch.setattr("darwin_mgmt_nic.settings.get_config_paths", lambda: [base, local])
+
+        settings = load_settings()
+
+        assert settings.config_sources == [str(base), str(local)]
+        assert settings.default_profile == "homelab"
+        assert settings.preserve_wifi is False
+        assert settings.show_dashboard is True
+        assert settings.device_ip == "192.168.88.1"
+        assert settings.laptop_ip == "192.168.88.100"
+        assert settings.netmask == "255.255.0.0"
+        assert settings.mgmt_network == "192.168.88.0/24"
+        assert settings.device_name == "Lab Management Device"
+        assert settings.profiles["homelab"].description == "USB OOB management path"
+        assert settings.profiles["homelab"].device_type == "network"
+
+    def test_env_profile_selects_profile_and_boolean_overrides(self, tmp_path, monkeypatch):
+        config = write_config(
+            tmp_path / "config.toml",
+            """
+            default_profile = "default"
+
+            [defaults]
+            preserve_wifi = false
+            dry_run = false
+            show_dashboard = false
+
+            [profiles.default]
+            device_ip = "192.0.2.1"
+            laptop_ip = "192.0.2.100"
+
+            [profiles.env]
+            device_ip = "203.0.113.1"
+            laptop_ip = "203.0.113.100"
+            mgmt_network = "203.0.113.0/24"
+            device_name = "Env Selected Device"
+            """,
+        )
+        monkeypatch.setattr("darwin_mgmt_nic.settings.get_config_paths", lambda: [config])
+        monkeypatch.setenv("DARWIN_NIC_PROFILE", "env")
+        monkeypatch.setenv("DARWIN_NIC_PRESERVE_WIFI", "yes")
+        monkeypatch.setenv("DARWIN_NIC_DRY_RUN", "1")
+        monkeypatch.setenv("DARWIN_NIC_SHOW_DASHBOARD", "true")
+
+        settings = load_settings()
+
+        assert settings.default_profile == "env"
+        assert settings.preserve_wifi is True
+        assert settings.dry_run is True
+        assert settings.show_dashboard is True
+        assert settings.device_ip == "203.0.113.1"
+        assert settings.laptop_ip == "203.0.113.100"
+        assert settings.mgmt_network == "203.0.113.0/24"
+        assert settings.device_name == "Env Selected Device"
+        assert "env:DARWIN_NIC_PROFILE" in settings.config_sources
+        assert "env:DARWIN_NIC_PRESERVE_WIFI" in settings.config_sources
+
+    def test_explicit_profile_beats_default_and_env_profile(self, tmp_path, monkeypatch):
+        config = write_config(
+            tmp_path / "config.toml",
+            """
+            default_profile = "default"
+
+            [profiles.default]
+            device_ip = "192.0.2.1"
+            laptop_ip = "192.0.2.100"
+
+            [profiles.env]
+            device_ip = "198.51.100.1"
+            laptop_ip = "198.51.100.100"
+
+            [profiles.cli]
+            device_ip = "203.0.113.1"
+            laptop_ip = "203.0.113.100"
+            """,
+        )
+        monkeypatch.setattr("darwin_mgmt_nic.settings.get_config_paths", lambda: [config])
+        monkeypatch.setenv("DARWIN_NIC_PROFILE", "env")
+
+        settings = load_settings(profile="cli")
+
+        assert settings.default_profile == "env"
+        assert settings.device_ip == "203.0.113.1"
+        assert settings.laptop_ip == "203.0.113.100"
+
+    def test_incomplete_profiles_are_skipped(self, tmp_path, monkeypatch, caplog):
+        config = write_config(
+            tmp_path / "config.toml",
+            """
+            [profiles.missing_laptop_ip]
+            device_ip = "192.0.2.1"
+
+            [profiles.complete]
+            device_ip = "192.0.2.2"
+            laptop_ip = "192.0.2.100"
+            """,
+        )
+        monkeypatch.setattr("darwin_mgmt_nic.settings.get_config_paths", lambda: [config])
+
+        with caplog.at_level(logging.WARNING):
+            settings = load_settings()
+
+        assert "missing_laptop_ip" not in settings.profiles
+        assert "complete" in settings.profiles
+        assert "missing required fields" in caplog.text
+
+    def test_malformed_config_is_skipped_and_later_config_still_loads(self, tmp_path, monkeypatch, caplog):
+        bad = write_config(tmp_path / "bad.toml", "[defaults]\ndevice_ip =")
+        good = write_config(
+            tmp_path / "good.toml",
+            """
+            [defaults]
+            device_ip = "192.0.2.10"
+            laptop_ip = "192.0.2.110"
+            """,
+        )
+        monkeypatch.setattr("darwin_mgmt_nic.settings.get_config_paths", lambda: [bad, good])
+
+        with caplog.at_level(logging.WARNING):
+            settings = load_settings()
+
+        assert settings.config_sources == [str(good)]
+        assert settings.device_ip == "192.0.2.10"
+        assert settings.laptop_ip == "192.0.2.110"
+        assert f"Failed to load {bad}" in caplog.text
+
+
+class TestInitConfig:
+    """Test config file initialization."""
+
+    def test_init_config_creates_file_and_respects_force(self, tmp_path, monkeypatch):
+        config_dir = tmp_path / "darwin-nic"
+        monkeypatch.setattr("darwin_mgmt_nic.settings.get_config_dir", lambda: config_dir)
+
+        config_path = init_config()
+        assert config_path == config_dir / "config.toml"
+        assert config_path.exists()
+        assert "[profiles.homelab]" in config_path.read_text()
+
+        config_path.write_text("custom = true\n")
+        assert init_config() is None
+        assert config_path.read_text() == "custom = true\n"
+
+        assert init_config(force=True) == config_path
+        assert "[profiles.homelab]" in config_path.read_text()

--- a/uv.lock
+++ b/uv.lock
@@ -168,7 +168,7 @@ wheels = [
 
 [[package]]
 name = "darwin-mgmt-nic-configurator"
-version = "2.0.0"
+version = "2.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "rich" },

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,42 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.14"
+
+[[package]]
+name = "babel"
+version = "2.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/b2/51899539b6ceeeb420d40ed3cd4b7a40519404f9baf3d4ac99dc413a834b/babel-2.18.0.tar.gz", hash = "sha256:b80b99a14bd085fcacfa15c9165f651fbb3406e66cc603abf11c5750937c992d", size = 9959554, upload-time = "2026-02-01T12:30:56.078Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/f5/21d2de20e8b8b0408f0681956ca2c69f1320a3848ac50e6e7f39c6159675/babel-2.18.0-py3-none-any.whl", hash = "sha256:e2b422b277c2b9a9630c1d7903c2a00d0830c409c59ac8cae9081c92f1aeba35", size = 10196845, upload-time = "2026-02-01T12:30:53.445Z" },
+]
+
+[[package]]
+name = "backrefs"
+version = "6.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/a6/e325ec73b638d3ede4421b5445d4a0b8b219481826cc079d510100af356c/backrefs-6.2.tar.gz", hash = "sha256:f44ff4d48808b243b6c0cdc6231e22195c32f77046018141556c66f8bab72a49", size = 7012303, upload-time = "2026-02-16T19:10:15.828Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/39/3765df263e08a4df37f4f43cb5aa3c6c17a4bdd42ecfe841e04c26037171/backrefs-6.2-py310-none-any.whl", hash = "sha256:0fdc7b012420b6b144410342caeb8adc54c6866cf12064abc9bb211302e496f8", size = 381075, upload-time = "2026-02-16T19:10:04.322Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/f0/35240571e1b67ffb19dafb29ab34150b6f59f93f717b041082cdb1bfceb1/backrefs-6.2-py311-none-any.whl", hash = "sha256:08aa7fae530c6b2361d7bdcbda1a7c454e330cc9dbcd03f5c23205e430e5c3be", size = 392874, upload-time = "2026-02-16T19:10:06.314Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/63/77e8c9745b4d227cce9f5e0a6f68041278c5f9b18588b35905f5f19c1beb/backrefs-6.2-py312-none-any.whl", hash = "sha256:c3f4b9cb2af8cda0d87ab4f57800b57b95428488477be164dd2b47be54db0c90", size = 398787, upload-time = "2026-02-16T19:10:08.274Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/71/c754b1737ad99102e03fa3235acb6cb6d3ac9d6f596cbc3e5f236705abd8/backrefs-6.2-py313-none-any.whl", hash = "sha256:12df81596ab511f783b7d87c043ce26bc5b0288cf3bb03610fe76b8189282b2b", size = 400747, upload-time = "2026-02-16T19:10:09.791Z" },
+    { url = "https://files.pythonhosted.org/packages/af/75/be12ba31a6eb20dccef2320cd8ccb3f7d9013b68ba4c70156259fee9e409/backrefs-6.2-py314-none-any.whl", hash = "sha256:e5f805ae09819caa1aa0623b4a83790e7028604aa2b8c73ba602c4454e665de7", size = 412602, upload-time = "2026-02-16T19:10:12.317Z" },
+    { url = "https://files.pythonhosted.org/packages/21/f8/d02f650c47d05034dcd6f9c8cf94f39598b7a89c00ecda0ecb2911bc27e9/backrefs-6.2-py39-none-any.whl", hash = "sha256:664e33cd88c6840b7625b826ecf2555f32d491800900f5a541f772c485f7cda7", size = 381077, upload-time = "2026-02-16T19:10:13.74Z" },
+]
+
+[[package]]
+name = "beautifulsoup4"
+version = "4.14.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "soupsieve" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b0/1c6a16426d389813b48d95e26898aff79abbde42ad353958ad95cc8c9b21/beautifulsoup4-4.14.3.tar.gz", hash = "sha256:6292b1c5186d356bba669ef9f7f051757099565ad9ada5dd630bd9de5fa7fb86", size = 627737, upload-time = "2025-11-30T15:08:26.084Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl", hash = "sha256:0918bfe44902e6ad8d57732ba310582e98da931428d231a5ecb9e7c703a735bb", size = 107721, upload-time = "2025-11-30T15:08:24.087Z" },
+]
 
 [[package]]
 name = "black"
@@ -22,6 +58,56 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/06/99/b2a4bd7dfaea7964974f947e1c76d6886d65fe5d24f687df2d85406b2609/black-25.12.0-cp314-cp314-win_amd64.whl", hash = "sha256:97596189949a8aad13ad12fcbb4ae89330039b96ad6742e6f6b45e75ad5cfd83", size = 1452042, upload-time = "2025-12-08T01:46:13.188Z" },
     { url = "https://files.pythonhosted.org/packages/b2/7c/d9825de75ae5dd7795d007681b752275ea85a1c5d83269b4b9c754c2aaab/black-25.12.0-cp314-cp314-win_arm64.whl", hash = "sha256:778285d9ea197f34704e3791ea9404cd6d07595745907dd2ce3da7a13627b29b", size = 1267446, upload-time = "2025-12-08T01:46:14.497Z" },
     { url = "https://files.pythonhosted.org/packages/68/11/21331aed19145a952ad28fca2756a1433ee9308079bd03bd898e903a2e53/black-25.12.0-py3-none-any.whl", hash = "sha256:48ceb36c16dbc84062740049eef990bb2ce07598272e673c17d1a7720c71c828", size = 206191, upload-time = "2025-12-08T01:40:50.963Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.4.22"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/25/ee/6caf7a40c36a1220410afe15a1cc64993a1f864871f698c0f93acb72842a/certifi-2026.4.22.tar.gz", hash = "sha256:8d455352a37b71bf76a79caa83a3d6c25afee4a385d632127b6afb3963f1c580", size = 137077, upload-time = "2026-04-22T11:26:11.191Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/30/7cd8fdcdfbc5b869528b079bfb76dcdf6056b1a2097a662e5e8c04f42965/certifi-2026.4.22-py3-none-any.whl", hash = "sha256:3cb2210c8f88ba2318d29b0388d1023c8492ff72ecdde4ebdaddbb13a31b1c4a", size = 135707, upload-time = "2026-04-22T11:26:09.372Z" },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/a1/67fe25fac3c7642725500a3f6cfe5821ad557c3abb11c9d20d12c7008d3e/charset_normalizer-3.4.7.tar.gz", hash = "sha256:ae89db9e5f98a11a4bf50407d4363e7b09b31e55bc117b4f7d80aab97ba009e5", size = 144271, upload-time = "2026-04-02T09:28:39.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/97/c8/c67cb8c70e19ef1960b97b22ed2a1567711de46c4ddf19799923adc836c2/charset_normalizer-3.4.7-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:c36c333c39be2dbca264d7803333c896ab8fa7d4d6f0ab7edb7dfd7aea6e98c0", size = 309234, upload-time = "2026-04-02T09:27:07.194Z" },
+    { url = "https://files.pythonhosted.org/packages/99/85/c091fdee33f20de70d6c8b522743b6f831a2f1cd3ff86de4c6a827c48a76/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1c2aed2e5e41f24ea8ef1590b8e848a79b56f3a5564a65ceec43c9d692dc7d8a", size = 208042, upload-time = "2026-04-02T09:27:08.749Z" },
+    { url = "https://files.pythonhosted.org/packages/87/1c/ab2ce611b984d2fd5d86a5a8a19c1ae26acac6bad967da4967562c75114d/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:54523e136b8948060c0fa0bc7b1b50c32c186f2fceee897a495406bb6e311d2b", size = 228706, upload-time = "2026-04-02T09:27:09.951Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/29/2b1d2cb00bf085f59d29eb773ce58ec2d325430f8c216804a0a5cd83cbca/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:715479b9a2802ecac752a3b0efa2b0b60285cf962ee38414211abdfccc233b41", size = 224727, upload-time = "2026-04-02T09:27:11.175Z" },
+    { url = "https://files.pythonhosted.org/packages/47/5c/032c2d5a07fe4d4855fea851209cca2b6f03ebeb6d4e3afdb3358386a684/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bd6c2a1c7573c64738d716488d2cdd3c00e340e4835707d8fdb8dc1a66ef164e", size = 215882, upload-time = "2026-04-02T09:27:12.446Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/c2/356065d5a8b78ed04499cae5f339f091946a6a74f91e03476c33f0ab7100/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:c45e9440fb78f8ddabcf714b68f936737a121355bf59f3907f4e17721b9d1aae", size = 200860, upload-time = "2026-04-02T09:27:13.721Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/cd/a32a84217ced5039f53b29f460962abb2d4420def55afabe45b1c3c7483d/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3534e7dcbdcf757da6b85a0bbf5b6868786d5982dd959b065e65481644817a18", size = 211564, upload-time = "2026-04-02T09:27:15.272Z" },
+    { url = "https://files.pythonhosted.org/packages/44/86/58e6f13ce26cc3b8f4a36b94a0f22ae2f00a72534520f4ae6857c4b81f89/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e8ac484bf18ce6975760921bb6148041faa8fef0547200386ea0b52b5d27bf7b", size = 211276, upload-time = "2026-04-02T09:27:16.834Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/fe/d17c32dc72e17e155e06883efa84514ca375f8a528ba2546bee73fc4df81/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:a5fe03b42827c13cdccd08e6c0247b6a6d4b5e3cdc53fd1749f5896adcdc2356", size = 201238, upload-time = "2026-04-02T09:27:18.229Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/29/f33daa50b06525a237451cdb6c69da366c381a3dadcd833fa5676bc468b3/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:2d6eb928e13016cea4f1f21d1e10c1cebd5a421bc57ddf5b1142ae3f86824fab", size = 230189, upload-time = "2026-04-02T09:27:19.445Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/6e/52c84015394a6a0bdcd435210a7e944c5f94ea1055f5cc5d56c5fe368e7b/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:e74327fb75de8986940def6e8dee4f127cc9752bee7355bb323cc5b2659b6d46", size = 211352, upload-time = "2026-04-02T09:27:20.79Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/d7/4353be581b373033fb9198bf1da3cf8f09c1082561e8e922aa7b39bf9fe8/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:d6038d37043bced98a66e68d3aa2b6a35505dc01328cd65217cefe82f25def44", size = 227024, upload-time = "2026-04-02T09:27:22.063Z" },
+    { url = "https://files.pythonhosted.org/packages/30/45/99d18aa925bd1740098ccd3060e238e21115fffbfdcb8f3ece837d0ace6c/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7579e913a5339fb8fa133f6bbcfd8e6749696206cf05acdbdca71a1b436d8e72", size = 217869, upload-time = "2026-04-02T09:27:23.486Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/5ee478aa53f4bb7996482153d4bfe1b89e0f087f0ab6b294fcf92d595873/charset_normalizer-3.4.7-cp314-cp314-win32.whl", hash = "sha256:5b77459df20e08151cd6f8b9ef8ef1f961ef73d85c21a555c7eed5b79410ec10", size = 148541, upload-time = "2026-04-02T09:27:25.146Z" },
+    { url = "https://files.pythonhosted.org/packages/48/77/72dcb0921b2ce86420b2d79d454c7022bf5be40202a2a07906b9f2a35c97/charset_normalizer-3.4.7-cp314-cp314-win_amd64.whl", hash = "sha256:92a0a01ead5e668468e952e4238cccd7c537364eb7d851ab144ab6627dbbe12f", size = 159634, upload-time = "2026-04-02T09:27:26.642Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/a3/c2369911cd72f02386e4e340770f6e158c7980267da16af8f668217abaa0/charset_normalizer-3.4.7-cp314-cp314-win_arm64.whl", hash = "sha256:67f6279d125ca0046a7fd386d01b311c6363844deac3e5b069b514ba3e63c246", size = 148384, upload-time = "2026-04-02T09:27:28.271Z" },
+    { url = "https://files.pythonhosted.org/packages/94/09/7e8a7f73d24dba1f0035fbbf014d2c36828fc1bf9c88f84093e57d315935/charset_normalizer-3.4.7-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:effc3f449787117233702311a1b7d8f59cba9ced946ba727bdc329ec69028e24", size = 330133, upload-time = "2026-04-02T09:27:29.474Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/da/96975ddb11f8e977f706f45cddd8540fd8242f71ecdb5d18a80723dcf62c/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fbccdc05410c9ee21bbf16a35f4c1d16123dcdeb8a1d38f33654fa21d0234f79", size = 216257, upload-time = "2026-04-02T09:27:30.793Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/e8/1d63bf8ef2d388e95c64b2098f45f84758f6d102a087552da1485912637b/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:733784b6d6def852c814bce5f318d25da2ee65dd4839a0718641c696e09a2960", size = 234851, upload-time = "2026-04-02T09:27:32.44Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/40/e5ff04233e70da2681fa43969ad6f66ca5611d7e669be0246c4c7aaf6dc8/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a89c23ef8d2c6b27fd200a42aa4ac72786e7c60d40efdc76e6011260b6e949c4", size = 233393, upload-time = "2026-04-02T09:27:34.03Z" },
+    { url = "https://files.pythonhosted.org/packages/be/c1/06c6c49d5a5450f76899992f1ee40b41d076aee9279b49cf9974d2f313d5/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6c114670c45346afedc0d947faf3c7f701051d2518b943679c8ff88befe14f8e", size = 223251, upload-time = "2026-04-02T09:27:35.369Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/9f/f2ff16fb050946169e3e1f82134d107e5d4ae72647ec8a1b1446c148480f/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:a180c5e59792af262bf263b21a3c49353f25945d8d9f70628e73de370d55e1e1", size = 206609, upload-time = "2026-04-02T09:27:36.661Z" },
+    { url = "https://files.pythonhosted.org/packages/69/d5/a527c0cd8d64d2eab7459784fb4169a0ac76e5a6fc5237337982fd61347e/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3c9a494bc5ec77d43cea229c4f6db1e4d8fe7e1bbffa8b6f0f0032430ff8ab44", size = 220014, upload-time = "2026-04-02T09:27:38.019Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/80/8a7b8104a3e203074dc9aa2c613d4b726c0e136bad1cc734594b02867972/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8d828b6667a32a728a1ad1d93957cdf37489c57b97ae6c4de2860fa749b8fc1e", size = 218979, upload-time = "2026-04-02T09:27:39.37Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9a/b759b503d507f375b2b5c153e4d2ee0a75aa215b7f2489cf314f4541f2c0/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:cf1493cd8607bec4d8a7b9b004e699fcf8f9103a9284cc94962cb73d20f9d4a3", size = 209238, upload-time = "2026-04-02T09:27:40.722Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/4e/0f3f5d47b86bdb79256e7290b26ac847a2832d9a4033f7eb2cd4bcf4bb5b/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:0c96c3b819b5c3e9e165495db84d41914d6894d55181d2d108cc1a69bfc9cce0", size = 236110, upload-time = "2026-04-02T09:27:42.33Z" },
+    { url = "https://files.pythonhosted.org/packages/96/23/bce28734eb3ed2c91dcf93abeb8a5cf393a7b2749725030bb630e554fdd8/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:752a45dc4a6934060b3b0dab47e04edc3326575f82be64bc4fc293914566503e", size = 219824, upload-time = "2026-04-02T09:27:43.924Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/6f/6e897c6984cc4d41af319b077f2f600fc8214eb2fe2d6bcb79141b882400/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:8778f0c7a52e56f75d12dae53ae320fae900a8b9b4164b981b9c5ce059cd1fcb", size = 233103, upload-time = "2026-04-02T09:27:45.348Z" },
+    { url = "https://files.pythonhosted.org/packages/76/22/ef7bd0fe480a0ae9b656189ec00744b60933f68b4f42a7bb06589f6f576a/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ce3412fbe1e31eb81ea42f4169ed94861c56e643189e1e75f0041f3fe7020abe", size = 225194, upload-time = "2026-04-02T09:27:46.706Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/a7/0e0ab3e0b5bc1219bd80a6a0d4d72ca74d9250cb2382b7c699c147e06017/charset_normalizer-3.4.7-cp314-cp314t-win32.whl", hash = "sha256:c03a41a8784091e67a39648f70c5f97b5b6a37f216896d44d2cdcb82615339a0", size = 159827, upload-time = "2026-04-02T09:27:48.053Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/1d/29d32e0fb40864b1f878c7f5a0b343ae676c6e2b271a2d55cc3a152391da/charset_normalizer-3.4.7-cp314-cp314t-win_amd64.whl", hash = "sha256:03853ed82eeebbce3c2abfdbc98c96dc205f32a79627688ac9a27370ea61a49c", size = 174168, upload-time = "2026-04-02T09:27:49.795Z" },
+    { url = "https://files.pythonhosted.org/packages/de/32/d92444ad05c7a6e41fb2036749777c163baf7a0301a040cb672d6b2b1ae9/charset_normalizer-3.4.7-cp314-cp314t-win_arm64.whl", hash = "sha256:c35abb8bfff0185efac5878da64c45dafd2b37fb0383add1be155a763c1f083d", size = 153018, upload-time = "2026-04-02T09:27:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/db/8f/61959034484a4a7c527811f4721e75d02d653a35afb0b6054474d8185d4c/charset_normalizer-3.4.7-py3-none-any.whl", hash = "sha256:3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d", size = 61958, upload-time = "2026-04-02T09:28:37.794Z" },
 ]
 
 [[package]]
@@ -92,6 +178,9 @@ dependencies = [
 [package.optional-dependencies]
 dev = [
     { name = "black" },
+    { name = "mkdocs" },
+    { name = "mkdocs-material" },
+    { name = "mkdocs-mermaid2-plugin" },
     { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-cov" },
@@ -103,6 +192,9 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "black", marker = "extra == 'dev'", specifier = ">=24.0.0" },
+    { name = "mkdocs", marker = "extra == 'dev'", specifier = ">=1.6.0" },
+    { name = "mkdocs-material", marker = "extra == 'dev'", specifier = ">=9.5.0" },
+    { name = "mkdocs-mermaid2-plugin", marker = "extra == 'dev'", specifier = ">=1.1.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.11.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5.0.0" },
@@ -113,6 +205,36 @@ requires-dist = [
     { name = "typing-extensions", specifier = ">=4.12.0" },
 ]
 provides-extras = ["dev"]
+
+[[package]]
+name = "editorconfig"
+version = "0.17.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/88/3a/a61d9a1f319a186b05d14df17daea42fcddea63c213bcd61a929fb3a6796/editorconfig-0.17.1.tar.gz", hash = "sha256:23c08b00e8e08cc3adcddb825251c497478df1dada6aefeb01e626ad37303745", size = 14695, upload-time = "2025-06-09T08:21:37.097Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/96/fd/a40c621ff207f3ce8e484aa0fc8ba4eb6e3ecf52e15b42ba764b457a9550/editorconfig-0.17.1-py3-none-any.whl", hash = "sha256:1eda9c2c0db8c16dbd50111b710572a5e6de934e39772de1959d41f64fc17c82", size = 16360, upload-time = "2025-06-09T08:21:35.654Z" },
+]
+
+[[package]]
+name = "ghp-import"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d9/29/d40217cbe2f6b1359e00c6c307bb3fc876ba74068cbab3dde77f03ca0dc4/ghp-import-2.1.0.tar.gz", hash = "sha256:9c535c4c61193c2df8871222567d7fd7e5014d835f97dc7b7439069e2413d343", size = 10943, upload-time = "2022-05-02T15:47:16.11Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f7/ec/67fbef5d497f86283db54c22eec6f6140243aae73265799baaaa19cd17fb/ghp_import-2.1.0-py3-none-any.whl", hash = "sha256:8337dd7b50877f163d4c0289bc1f1c7f127550241988d568c1db512c4324a619", size = 11034, upload-time = "2022-05-02T15:47:14.552Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.13"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ce/cc/762dfb036166873f0059f3b7de4565e1b5bc3d6f28a414c13da27e442f99/idna-3.13.tar.gz", hash = "sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242", size = 194210, upload-time = "2026-04-22T16:42:42.314Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/13/ad7d7ca3808a898b4612b6fe93cde56b53f3034dcde235acb1f0e1df24c6/idna-3.13-py3-none-any.whl", hash = "sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3", size = 68629, upload-time = "2026-04-22T16:42:40.909Z" },
+]
 
 [[package]]
 name = "iniconfig"
@@ -133,6 +255,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "jsbeautifier"
+version = "1.15.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "editorconfig" },
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ea/98/d6cadf4d5a1c03b2136837a435682418c29fdeb66be137128544cecc5b7a/jsbeautifier-1.15.4.tar.gz", hash = "sha256:5bb18d9efb9331d825735fbc5360ee8f1aac5e52780042803943aa7f854f7592", size = 75257, upload-time = "2025-02-27T17:53:53.252Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2d/14/1c65fccf8413d5f5c6e8425f84675169654395098000d8bddc4e9d3390e1/jsbeautifier-1.15.4-py3-none-any.whl", hash = "sha256:72f65de312a3f10900d7685557f84cb61a9733c50dcc27271a39f5b0051bf528", size = 94707, upload-time = "2025-02-27T17:53:46.152Z" },
 ]
 
 [[package]]
@@ -163,6 +298,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/22/f0/07fb6ab5c39a4ca9af3e37554f9d42f25c464829254d72e4ebbd81da351c/librt-0.7.8-cp314-cp314t-win32.whl", hash = "sha256:171ca3a0a06c643bd0a2f62a8944e1902c94aa8e5da4db1ea9a8daf872685365", size = 41173, upload-time = "2026-01-14T12:55:59.315Z" },
     { url = "https://files.pythonhosted.org/packages/24/d4/7e4be20993dc6a782639625bd2f97f3c66125c7aa80c82426956811cfccf/librt-0.7.8-cp314-cp314t-win_amd64.whl", hash = "sha256:445b7304145e24c60288a2f172b5ce2ca35c0f81605f5299f3fa567e189d2e32", size = 47668, upload-time = "2026-01-14T12:56:00.261Z" },
     { url = "https://files.pythonhosted.org/packages/fc/85/69f92b2a7b3c0f88ffe107c86b952b397004b5b8ea5a81da3d9c04c04422/librt-0.7.8-cp314-cp314t-win_arm64.whl", hash = "sha256:8766ece9de08527deabcd7cb1b4f1a967a385d26e33e536d6d8913db6ef74f06", size = 40550, upload-time = "2026-01-14T12:56:01.542Z" },
+]
+
+[[package]]
+name = "markdown"
+version = "3.10.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2b/f4/69fa6ed85ae003c2378ffa8f6d2e3234662abd02c10d216c0ba96081a238/markdown-3.10.2.tar.gz", hash = "sha256:994d51325d25ad8aa7ce4ebaec003febcce822c3f8c911e3b17c52f7f589f950", size = 368805, upload-time = "2026-02-09T14:57:26.942Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/1f/77fa3081e4f66ca3576c896ae5d31c3002ac6607f9747d2e3aa49227e464/markdown-3.10.2-py3-none-any.whl", hash = "sha256:e91464b71ae3ee7afd3017d9f358ef0baf158fd9a298db92f1d4761133824c36", size = 108180, upload-time = "2026-02-09T14:57:25.787Z" },
 ]
 
 [[package]]
@@ -217,6 +361,101 @@ wheels = [
 ]
 
 [[package]]
+name = "mergedeep"
+version = "1.3.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3a/41/580bb4006e3ed0361b8151a01d324fb03f420815446c7def45d02f74c270/mergedeep-1.3.4.tar.gz", hash = "sha256:0096d52e9dad9939c3d975a774666af186eda617e6ca84df4c94dec30004f2a8", size = 4661, upload-time = "2021-02-05T18:55:30.623Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/19/04f9b178c2d8a15b076c8b5140708fa6ffc5601fb6f1e975537072df5b2a/mergedeep-1.3.4-py3-none-any.whl", hash = "sha256:70775750742b25c0d8f36c55aed03d24c3384d17c951b3175d898bd778ef0307", size = 6354, upload-time = "2021-02-05T18:55:29.583Z" },
+]
+
+[[package]]
+name = "mkdocs"
+version = "1.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "ghp-import" },
+    { name = "jinja2" },
+    { name = "markdown" },
+    { name = "markupsafe" },
+    { name = "mergedeep" },
+    { name = "mkdocs-get-deps" },
+    { name = "packaging" },
+    { name = "pathspec" },
+    { name = "pyyaml" },
+    { name = "pyyaml-env-tag" },
+    { name = "watchdog" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bc/c6/bbd4f061bd16b378247f12953ffcb04786a618ce5e904b8c5a01a0309061/mkdocs-1.6.1.tar.gz", hash = "sha256:7b432f01d928c084353ab39c57282f29f92136665bdd6abf7c1ec8d822ef86f2", size = 3889159, upload-time = "2024-08-30T12:24:06.899Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/5b/dbc6a8cddc9cfa9c4971d59fb12bb8d42e161b7e7f8cc89e49137c5b279c/mkdocs-1.6.1-py3-none-any.whl", hash = "sha256:db91759624d1647f3f34aa0c3f327dd2601beae39a366d6e064c03468d35c20e", size = 3864451, upload-time = "2024-08-30T12:24:05.054Z" },
+]
+
+[[package]]
+name = "mkdocs-get-deps"
+version = "0.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mergedeep" },
+    { name = "platformdirs" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ce/25/b3cccb187655b9393572bde9b09261d267c3bf2f2cdabe347673be5976a6/mkdocs_get_deps-0.2.2.tar.gz", hash = "sha256:8ee8d5f316cdbbb2834bc1df6e69c08fe769a83e040060de26d3c19fad3599a1", size = 11047, upload-time = "2026-03-10T02:46:33.632Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/29/744136411e785c4b0b744d5413e56555265939ab3a104c6a4b719dad33fd/mkdocs_get_deps-0.2.2-py3-none-any.whl", hash = "sha256:e7878cbeac04860b8b5e0ca31d3abad3df9411a75a32cde82f8e44b6c16ff650", size = 9555, upload-time = "2026-03-10T02:46:32.256Z" },
+]
+
+[[package]]
+name = "mkdocs-material"
+version = "9.7.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "babel" },
+    { name = "backrefs" },
+    { name = "colorama" },
+    { name = "jinja2" },
+    { name = "markdown" },
+    { name = "mkdocs" },
+    { name = "mkdocs-material-extensions" },
+    { name = "paginate" },
+    { name = "pygments" },
+    { name = "pymdown-extensions" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/45/29/6d2bcf41ae40802c4beda2432396fff97b8456fb496371d1bc7aad6512ec/mkdocs_material-9.7.6.tar.gz", hash = "sha256:00bdde50574f776d328b1862fe65daeaf581ec309bd150f7bff345a098c64a69", size = 4097959, upload-time = "2026-03-19T15:41:58.161Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/01/bc663630c510822c95c47a66af9fa7a443c295b47d5f041e5e6ae62ef659/mkdocs_material-9.7.6-py3-none-any.whl", hash = "sha256:71b84353921b8ea1ba84fe11c50912cc512da8fe0881038fcc9a0761c0e635ba", size = 9305470, upload-time = "2026-03-19T15:41:55.217Z" },
+]
+
+[[package]]
+name = "mkdocs-material-extensions"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/79/9b/9b4c96d6593b2a541e1cb8b34899a6d021d208bb357042823d4d2cabdbe7/mkdocs_material_extensions-1.3.1.tar.gz", hash = "sha256:10c9511cea88f568257f960358a467d12b970e1f7b2c0e5fb2bb48cab1928443", size = 11847, upload-time = "2023-11-22T19:09:45.208Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5b/54/662a4743aa81d9582ee9339d4ffa3c8fd40a4965e033d77b9da9774d3960/mkdocs_material_extensions-1.3.1-py3-none-any.whl", hash = "sha256:adff8b62700b25cb77b53358dad940f3ef973dd6db797907c49e3c2ef3ab4e31", size = 8728, upload-time = "2023-11-22T19:09:43.465Z" },
+]
+
+[[package]]
+name = "mkdocs-mermaid2-plugin"
+version = "1.2.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "beautifulsoup4" },
+    { name = "jsbeautifier" },
+    { name = "mkdocs" },
+    { name = "pymdown-extensions" },
+    { name = "requests" },
+    { name = "setuptools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2a/6d/308f443a558b6a97ce55782658174c0d07c414405cfc0a44d36ad37e36f9/mkdocs_mermaid2_plugin-1.2.3.tar.gz", hash = "sha256:fb6f901d53e5191e93db78f93f219cad926ccc4d51e176271ca5161b6cc5368c", size = 16220, upload-time = "2025-10-17T19:38:53.047Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1a/4b/6fd6dd632019b7f522f1b1f794ab6115cd79890330986614be56fd18f0eb/mkdocs_mermaid2_plugin-1.2.3-py3-none-any.whl", hash = "sha256:33f60c582be623ed53829a96e19284fc7f1b74a1dbae78d4d2e47fe00c3e190d", size = 17299, upload-time = "2025-10-17T19:38:51.874Z" },
+]
+
+[[package]]
 name = "mypy"
 version = "1.19.1"
 source = { registry = "https://pypi.org/simple" }
@@ -256,6 +495,15 @@ wheels = [
 ]
 
 [[package]]
+name = "paginate"
+version = "0.5.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ec/46/68dde5b6bc00c1296ec6466ab27dddede6aec9af1b99090e1107091b3b84/paginate-0.5.7.tar.gz", hash = "sha256:22bd083ab41e1a8b4f3690544afb2c60c25e5c9a63a30fa2f483f6c60c8e5945", size = 19252, upload-time = "2024-08-25T14:17:24.139Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/96/04b8e52da071d28f5e21a805b19cb9390aa17a47462ac87f5e2696b9566d/paginate-0.5.7-py2.py3-none-any.whl", hash = "sha256:b885e2af73abcf01d9559fd5216b57ef722f8c42affbb63942377668e35c7591", size = 13746, upload-time = "2024-08-25T14:17:22.55Z" },
+]
+
+[[package]]
 name = "pathspec"
 version = "1.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -289,6 +537,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
+name = "pymdown-extensions"
+version = "10.21.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/08/f1c908c581fd11913da4711ea7ba32c0eee40b0190000996bb863b0c9349/pymdown_extensions-10.21.2.tar.gz", hash = "sha256:c3f55a5b8a1d0edf6699e35dcbea71d978d34ff3fa79f3d807b8a5b3fa90fbdc", size = 853922, upload-time = "2026-03-29T15:01:55.233Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f7/27/a2fc51a4a122dfd1015e921ae9d22fee3d20b0b8080d9a704578bf9deece/pymdown_extensions-10.21.2-py3-none-any.whl", hash = "sha256:5c0fd2a2bea14eb39af8ff284f1066d898ab2187d81b889b75d46d4348c01638", size = 268901, upload-time = "2026-03-29T15:01:53.244Z" },
 ]
 
 [[package]]
@@ -360,12 +621,77 @@ wheels = [
 ]
 
 [[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
 name = "pytokens"
 version = "0.3.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/4e/8d/a762be14dae1c3bf280202ba3172020b2b0b4c537f94427435f19c413b72/pytokens-0.3.0.tar.gz", hash = "sha256:2f932b14ed08de5fcf0b391ace2642f858f1394c0857202959000b68ed7a458a", size = 17644, upload-time = "2025-11-05T13:36:35.34Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/84/25/d9db8be44e205a124f6c98bc0324b2bb149b7431c53877fc6d1038dddaf5/pytokens-0.3.0-py3-none-any.whl", hash = "sha256:95b2b5eaf832e469d141a378872480ede3f251a5a5041b8ec6e581d3ac71bbf3", size = 12195, upload-time = "2025-11-05T13:36:33.183Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "pyyaml-env-tag"
+version = "1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/2e/79c822141bfd05a853236b504869ebc6b70159afc570e1d5a20641782eaa/pyyaml_env_tag-1.1.tar.gz", hash = "sha256:2eb38b75a2d21ee0475d6d97ec19c63287a7e140231e4214969d0eac923cd7ff", size = 5737, upload-time = "2025-05-13T15:24:01.64Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/11/432f32f8097b03e3cd5fe57e88efb685d964e2e5178a48ed61e841f7fdce/pyyaml_env_tag-1.1-py3-none-any.whl", hash = "sha256:17109e1a528561e32f026364712fee1264bc2ea6715120891174ed1b980d2e04", size = 4722, upload-time = "2025-05-13T15:23:59.629Z" },
+]
+
+[[package]]
+name = "requests"
+version = "2.33.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5f/a4/98b9c7c6428a668bf7e42ebb7c79d576a1c3c1e3ae2d47e674b468388871/requests-2.33.1.tar.gz", hash = "sha256:18817f8c57c6263968bc123d237e3b8b08ac046f5456bd1e307ee8f4250d3517", size = 134120, upload-time = "2026-03-30T16:09:15.531Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/8e/7540e8a2036f79a125c1d2ebadf69ed7901608859186c856fa0388ef4197/requests-2.33.1-py3-none-any.whl", hash = "sha256:4e6d1ef462f3626a1f0a0a9c42dd93c63bad33f9f1c1937509b8c5c8718ab56a", size = 64947, upload-time = "2026-03-30T16:09:13.83Z" },
 ]
 
 [[package]]
@@ -408,10 +734,64 @@ wheels = [
 ]
 
 [[package]]
+name = "setuptools"
+version = "82.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4f/db/cfac1baf10650ab4d1c111714410d2fbb77ac5a616db26775db562c8fab2/setuptools-82.0.1.tar.gz", hash = "sha256:7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9", size = 1152316, upload-time = "2026-03-09T12:47:17.221Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/76/f789f7a86709c6b087c5a2f52f911838cad707cc613162401badc665acfe/setuptools-82.0.1-py3-none-any.whl", hash = "sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb", size = 1006223, upload-time = "2026-03-09T12:47:15.026Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "soupsieve"
+version = "2.8.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/ae/2d9c981590ed9999a0d91755b47fc74f74de286b0f5cee14c9269041e6c4/soupsieve-2.8.3.tar.gz", hash = "sha256:3267f1eeea4251fb42728b6dfb746edc9acaffc4a45b27e19450b676586e8349", size = 118627, upload-time = "2026-01-20T04:27:02.457Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/2c/1462b1d0a634697ae9e55b3cecdcb64788e8b7d63f54d923fcd0bb140aed/soupsieve-2.8.3-py3-none-any.whl", hash = "sha256:ed64f2ba4eebeab06cc4962affce381647455978ffc1e36bb79a545b91f45a95", size = 37016, upload-time = "2026-01-20T04:27:01.012Z" },
+]
+
+[[package]]
 name = "typing-extensions"
 version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+]
+
+[[package]]
+name = "watchdog"
+version = "6.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/db/7d/7f3d619e951c88ed75c6037b246ddcf2d322812ee8ea189be89511721d54/watchdog-6.0.0.tar.gz", hash = "sha256:9ddf7c82fda3ae8e24decda1338ede66e1c99883db93711d8fb941eaa2d8c282", size = 131220, upload-time = "2024-11-01T14:07:13.037Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a9/c7/ca4bf3e518cb57a686b2feb4f55a1892fd9a3dd13f470fca14e00f80ea36/watchdog-6.0.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:7607498efa04a3542ae3e05e64da8202e58159aa1fa4acddf7678d34a35d4f13", size = 79079, upload-time = "2024-11-01T14:06:59.472Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/51/d46dc9332f9a647593c947b4b88e2381c8dfc0942d15b8edc0310fa4abb1/watchdog-6.0.0-py3-none-manylinux2014_armv7l.whl", hash = "sha256:9041567ee8953024c83343288ccc458fd0a2d811d6a0fd68c4c22609e3490379", size = 79078, upload-time = "2024-11-01T14:07:01.431Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/57/04edbf5e169cd318d5f07b4766fee38e825d64b6913ca157ca32d1a42267/watchdog-6.0.0-py3-none-manylinux2014_i686.whl", hash = "sha256:82dc3e3143c7e38ec49d61af98d6558288c415eac98486a5c581726e0737c00e", size = 79076, upload-time = "2024-11-01T14:07:02.568Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/cc/da8422b300e13cb187d2203f20b9253e91058aaf7db65b74142013478e66/watchdog-6.0.0-py3-none-manylinux2014_ppc64.whl", hash = "sha256:212ac9b8bf1161dc91bd09c048048a95ca3a4c4f5e5d4a7d1b1a7d5752a7f96f", size = 79077, upload-time = "2024-11-01T14:07:03.893Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/3b/b8964e04ae1a025c44ba8e4291f86e97fac443bca31de8bd98d3263d2fcf/watchdog-6.0.0-py3-none-manylinux2014_ppc64le.whl", hash = "sha256:e3df4cbb9a450c6d49318f6d14f4bbc80d763fa587ba46ec86f99f9e6876bb26", size = 79078, upload-time = "2024-11-01T14:07:05.189Z" },
+    { url = "https://files.pythonhosted.org/packages/62/ae/a696eb424bedff7407801c257d4b1afda455fe40821a2be430e173660e81/watchdog-6.0.0-py3-none-manylinux2014_s390x.whl", hash = "sha256:2cce7cfc2008eb51feb6aab51251fd79b85d9894e98ba847408f662b3395ca3c", size = 79077, upload-time = "2024-11-01T14:07:06.376Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/e8/dbf020b4d98251a9860752a094d09a65e1b436ad181faf929983f697048f/watchdog-6.0.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:20ffe5b202af80ab4266dcd3e91aae72bf2da48c0d33bdb15c66658e685e94e2", size = 79078, upload-time = "2024-11-01T14:07:07.547Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f6/d0e5b343768e8bcb4cda79f0f2f55051bf26177ecd5651f84c07567461cf/watchdog-6.0.0-py3-none-win32.whl", hash = "sha256:07df1fdd701c5d4c8e55ef6cf55b8f0120fe1aef7ef39a1c6fc6bc2e606d517a", size = 79065, upload-time = "2024-11-01T14:07:09.525Z" },
+    { url = "https://files.pythonhosted.org/packages/db/d9/c495884c6e548fce18a8f40568ff120bc3a4b7b99813081c8ac0c936fa64/watchdog-6.0.0-py3-none-win_amd64.whl", hash = "sha256:cbafb470cf848d93b5d013e2ecb245d4aa1c8fd0504e863ccefa32445359d680", size = 79070, upload-time = "2024-11-01T14:07:10.686Z" },
+    { url = "https://files.pythonhosted.org/packages/33/e8/e40370e6d74ddba47f002a32919d91310d6074130fe4e17dabcafc15cbf1/watchdog-6.0.0-py3-none-win_ia64.whl", hash = "sha256:a1914259fa9e1454315171103c6a30961236f508b9b623eae470268bbcc6a22f", size = 79067, upload-time = "2024-11-01T14:07:11.845Z" },
 ]


### PR DESCRIPTION
## Summary

Prepares DarwinNicUtil for the v2.1 release lane as a generic USB management NIC tool.

Changes include:

- refresh README and MkDocs for accurate platform, bastion, and artifact status
- add release sprint plan, artifact policy, generic bastion guide, changelog, and llms.txt
- add GitHub Actions for CI, docs deploy, secret detection, and tag-based release artifacts
- add gitleaks and git-cliff configuration
- add focused tests across settings, CLI/app dispatch, Linux placeholder behavior, network manager paths, docs boundaries, and dry-run safety
- add a 40 percent coverage gate
- propagate `darwin-nic configure` exit codes and keep dry-run from applying service-order preservation before validation
- keep downstream CRS/topology policy out of this repo

## Release Scope

Primary v2.1 artifacts are wheel/source distributions, Nix package outputs, MkDocs site artifacts, and GitHub Release attachments from `dist/*`.

PyPI trusted publishing, standalone PyInstaller binaries, Homebrew, Sophos, and ABR work remain follow-up scope unless explicitly pulled into v2.1.

## Tracking

- Linear initiative/project: DarwinNicUtil v2.1 Release Readiness
- Release gates: TIN-561, TIN-562, TIN-563, TIN-564, TIN-565
- Related GitHub issue: #4

## Validation

Local validation passed:

- `just check`
- `just test`
- `uv run --extra dev python -m pytest -q --cov=darwin_mgmt_nic --cov-report=term-missing`
- `uv run --extra dev mkdocs build --strict`
- `uv build`
- clean wheel install smoke test
- `nix run nixpkgs#gitleaks -- detect --source . --config .gitleaks.toml --verbose --exit-code 1`
- `nix flake check --print-build-logs`
- `nix run nixpkgs#actionlint -- -color`

Remaining release gate: hardware dry-run with a USB management NIC physically attached.
