### PR TITLE
Restrict release asset globs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,9 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: python-dist
-          path: dist/*
+          path: |
+            dist/*.whl
+            dist/*.tar.gz
 
       - name: Publish GitHub Release
         if: startsWith(github.ref, 'refs/tags/')
@@ -65,4 +67,6 @@ jobs:
         with:
           name: DarwinNicUtil ${{ github.ref_name }}
           generate_release_notes: true
-          files: dist/*
+          files: |
+            dist/*.whl
+            dist/*.tar.gz

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to DarwinNicUtil are recorded here.
 
 ## Unreleased
 
-- No changes yet.
+- Restrict future release workflow uploads to wheel and source distribution
+  artifacts only.
 
 ## 2.1.0 - 2026-04-25
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -113,6 +113,7 @@ git tag -a v2.1.0 -m "Release v2.1.0"
 git push origin v2.1.0
 ```
 
-The release workflow attaches `dist/*` to the GitHub Release. PyPI trusted
-publishing and standalone binary distribution are follow-up release tasks unless
-they are explicitly enabled before the tag.
+The release workflow attaches only wheel and source distribution files from
+`dist/` to the GitHub Release. PyPI trusted publishing and standalone binary
+distribution are follow-up release tasks unless they are explicitly enabled
+before the tag.

--- a/docs/superpowers/release-sprint-plan.md
+++ b/docs/superpowers/release-sprint-plan.md
@@ -110,7 +110,7 @@ them as complete.
 The v2.1.0 release should publish:
 
 - wheel and source distribution from `uv build`;
-- GitHub Release notes and attached `dist/*` artifacts;
+- GitHub Release notes with attached wheel and source distribution artifacts;
 - MkDocs site through GitHub Pages;
 - Nix package availability through the flake.
 


### PR DESCRIPTION
## Summary

Restricts release upload patterns to Python wheel and source distribution artifacts only, and updates release docs so the artifact policy matches the workflow. The v2.1.0 release briefly picked up `dist/.gitignore` as a `default.gitignore` asset because the workflow used `dist/*`; that asset has already been removed from the published release.

## Validation

- `nix run nixpkgs#actionlint -- -color`
- `uv run --extra dev python -m pytest tests/test_docs.py -q`
- `uv run --extra dev mkdocs build --strict`
