### PR TITLE
Clarify release artifact docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to DarwinNicUtil are recorded here.
 
 - Restrict future release workflow uploads to wheel and source distribution
   artifacts only.
+- Clarify release artifact docs so they describe only wheel and source
+  distribution uploads.
 
 ## 2.1.0 - 2026-04-25
 

--- a/docs/artifacts.md
+++ b/docs/artifacts.md
@@ -58,8 +58,9 @@ Pages artifact.
 
 ## GitHub Release
 
-The release workflow runs on tags matching `v*.*.*`. It builds `dist/*` and
-attaches the wheel and source distribution to the GitHub Release.
+The release workflow runs on tags matching `v*.*.*`. It builds the Python
+distribution files and attaches only the wheel and source distribution to the
+GitHub Release.
 
 ## Not Yet Primary Artifacts
 


### PR DESCRIPTION
## Summary

Clarifies the artifact policy docs so they describe wheel and source distribution uploads rather than broad `dist/*` handling.

## Validation

- `uv run --extra dev python -m pytest tests/test_docs.py -q`
- `uv run --extra dev mkdocs build --strict`
