### PR TITLE
Define agent integration surface

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,17 @@ darwin-nic status
 darwin-nic configure --profile homelab --preserve-wifi
 ```
 
+## Agent and MCP Surface
+
+This repo intentionally does not ship a `.mcp.json` today. The maintained
+agent-facing surfaces are:
+
+- `AGENTS.md` for repo boundaries, validation, and operator constraints;
+- `docs/llms.txt` for compact model-facing documentation context.
+
+Add a repo-local MCP config only when DarwinNicUtil owns a stable, generic MCP
+integration. Do not encode sibling-repo control-plane details here.
+
 ## Validation
 
 Run the full Python test suite after changing runtime behavior or docs that are covered by tests:

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -19,6 +19,9 @@ Important boundaries:
   host-side diagnostics.
 - Device-specific topology, credentials, MAC addresses, and switch policy belong
   in consuming operator runbooks.
+- There is no repo-local `.mcp.json` at this time. `AGENTS.md` and this file are
+  the maintained agent-facing integration surfaces until a generic MCP
+  integration exists.
 - The generic bastion commands are:
 
 ```bash

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -55,6 +55,16 @@ def test_agents_file_keeps_crs_policy_out_of_darwin_tool():
     assert "vault_mikrotik_password" not in agents
 
 
+def test_agent_surface_documents_no_repo_local_mcp_config():
+    agents = (REPO_ROOT / "AGENTS.md").read_text()
+    llms = (REPO_ROOT / "docs" / "llms.txt").read_text()
+
+    assert not (REPO_ROOT / ".mcp.json").exists()
+    assert "does not ship a `.mcp.json` today" in agents
+    assert "There is no repo-local `.mcp.json` at this time" in llms
+    assert "sibling-repo control-plane details" in agents
+
+
 def test_bastion_docs_keep_device_specific_policy_out_of_darwin_tool():
     bastion = (REPO_ROOT / "docs" / "bastion.md").read_text()
     llms = (REPO_ROOT / "docs" / "llms.txt").read_text()


### PR DESCRIPTION
## Summary

Documents that DarwinNicUtil intentionally does not ship a repo-local `.mcp.json` today. `AGENTS.md` and `docs/llms.txt` are the maintained agent-facing integration surfaces until the repo owns a stable, generic MCP integration.

Adds a docs test to keep that decision explicit and prevent sibling-repo control-plane details from drifting into this generic tool repo.

Closes #13.

## Validation

- `uv run --extra dev python -m pytest tests/test_docs.py -q`
- `uv run --extra dev mkdocs build --strict`
