### PR TITLE
Track distribution follow-up surfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to DarwinNicUtil are recorded here.
   artifacts only.
 - Clarify release artifact docs so they describe only wheel and source
   distribution uploads.
+- Track post-v2.1 distribution follow-ups for PyPI, standalone binaries,
+  Homebrew, FlakeHub, and Bazel/BCR without advertising unproven install paths.
 
 ## 2.1.0 - 2026-04-25
 

--- a/docs/artifacts.md
+++ b/docs/artifacts.md
@@ -66,7 +66,13 @@ GitHub Release.
 
 | Surface | Current status |
 |---------|----------------|
-| PyPI | Planned through trusted publishing, not currently required for release |
-| Standalone binary | PyInstaller spec exists, but binary releases are not validated yet |
-| Homebrew | Not shipped |
+| PyPI | Planned through trusted publishing; tracked in [GitHub #11](https://github.com/Jesssullivan/DarwinNicUtil/issues/11) |
+| Standalone binary | PyInstaller spec exists, but binary releases are not validated yet; tracked in [GitHub #9](https://github.com/Jesssullivan/DarwinNicUtil/issues/9) |
+| Homebrew | Not shipped; formula strategy depends on the binary or PyPI decision and is tracked in [GitHub #10](https://github.com/Jesssullivan/DarwinNicUtil/issues/10) |
+| FlakeHub | Existing Nix flake may be publishable, but FlakeHub is not advertised until proven; tracked in [GitHub #16](https://github.com/Jesssullivan/DarwinNicUtil/issues/16) |
+| Bazel / BCR | Not a primary install path; evaluate only if a real downstream Bazel/Bzlmod consumer needs it, tracked in [GitHub #17](https://github.com/Jesssullivan/DarwinNicUtil/issues/17) |
 | Container image | Not applicable for the CLI today |
+
+Homebrew, FlakeHub, and Bazel/BCR work should stay aligned with the broader
+Tinyland distribution substrate, but this repo should only document public,
+validated install paths.


### PR DESCRIPTION
## Summary

Updates the artifact policy docs to name the post-v2.1 distribution follow-ups now tracked in GitHub/Linear: PyPI, standalone binaries, Homebrew, FlakeHub, and Bazel/BCR.

The docs keep the public install story conservative: these surfaces are tracked but not advertised as supported until validated.

## Validation

- `uv run --extra dev python -m pytest tests/test_docs.py -q`
- `uv run --extra dev mkdocs build --strict`
