### PR TITLE
Defer Homebrew distribution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to DarwinNicUtil are recorded here.
   distribution uploads.
 - Track post-v2.1 distribution follow-ups for PyPI, standalone binaries,
   Homebrew, FlakeHub, and Bazel/BCR without advertising unproven install paths.
+- Mark Homebrew as deferred until a supported PyPI or standalone artifact exists.
 
 ## 2.1.0 - 2026-04-25
 

--- a/docs/artifacts.md
+++ b/docs/artifacts.md
@@ -68,11 +68,12 @@ GitHub Release.
 |---------|----------------|
 | PyPI | Planned through trusted publishing; tracked in [GitHub #11](https://github.com/Jesssullivan/DarwinNicUtil/issues/11) |
 | Standalone binary | PyInstaller spec exists, but binary releases are not validated yet; tracked in [GitHub #9](https://github.com/Jesssullivan/DarwinNicUtil/issues/9) |
-| Homebrew | Not shipped; formula strategy depends on the binary or PyPI decision and is tracked in [GitHub #10](https://github.com/Jesssullivan/DarwinNicUtil/issues/10) |
+| Homebrew | Deferred; there is no active DarwinNicUtil tap/formula path until PyPI or standalone artifacts are proven, with the decision recorded in [GitHub #10](https://github.com/Jesssullivan/DarwinNicUtil/issues/10) |
 | FlakeHub | Existing Nix flake may be publishable, but FlakeHub is not advertised until proven; tracked in [GitHub #16](https://github.com/Jesssullivan/DarwinNicUtil/issues/16) |
 | Bazel / BCR | Not a primary install path; evaluate only if a real downstream Bazel/Bzlmod consumer needs it, tracked in [GitHub #17](https://github.com/Jesssullivan/DarwinNicUtil/issues/17) |
 | Container image | Not applicable for the CLI today |
 
-Homebrew, FlakeHub, and Bazel/BCR work should stay aligned with the broader
-Tinyland distribution substrate, but this repo should only document public,
+FlakeHub and Bazel/BCR work should stay aligned with the broader Tinyland
+distribution substrate. Homebrew should be reconsidered only after a supported
+PyPI or standalone artifact exists. This repo should only document public,
 validated install paths.

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -120,7 +120,8 @@ def test_artifacts_docs_match_current_release_policy():
     assert "Nix packages" in artifacts
     assert "Standalone binary" in artifacts
     assert "not validated yet" in artifacts
-    assert "Homebrew | Not shipped" in artifacts
+    assert "Homebrew | Deferred" in artifacts
+    assert "no active DarwinNicUtil tap/formula path" in artifacts
     assert "PyPI publishing and standalone binary distribution remain tracked release" in readme
 
 


### PR DESCRIPTION
## Summary

Marks Homebrew as deferred for DarwinNicUtil until either PyPI trusted publishing or standalone release artifacts are proven. This avoids anchoring the repo to the stale tap surface while keeping the decision recorded.

Closes #10.

## Validation

- `uv run --extra dev python -m pytest tests/test_docs.py -q`
- `uv run --extra dev mkdocs build --strict`
