### PR TITLE
[codex] stage FlakeHub publication workflow

### DIFF
--- a/.github/workflows/flakehub-publish.yml
+++ b/.github/workflows/flakehub-publish.yml
@@ -1,0 +1,77 @@
+name: Publish to FlakeHub
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing v* tag to publish; leave blank for manual rolling validation"
+        required: false
+        type: string
+      rolling:
+        description: "Publish the checked-out ref as a rolling FlakeHub release"
+        required: true
+        default: false
+        type: boolean
+      visibility:
+        description: "FlakeHub visibility"
+        required: true
+        default: public
+        type: choice
+        options:
+          - public
+          - unlisted
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ inputs.tag || 'current' }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Publish flake
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate publish mode
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          TAG: ${{ inputs.tag }}
+          ROLLING: ${{ inputs.rolling }}
+        run: |
+          set -euo pipefail
+          if [[ "${EVENT_NAME}" == "workflow_dispatch" && -z "${TAG}" && "${ROLLING}" != "true" ]]; then
+            echo "Provide a tag or set rolling=true for manual FlakeHub publication."
+            exit 1
+          fi
+
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.tag || github.ref }}
+
+      - name: Install Determinate Nix
+        uses: DeterminateSystems/determinate-nix-action@v3
+
+      - name: Check flake
+        run: nix flake check --print-build-logs
+
+      - name: Publish tagged release
+        if: github.ref_type == 'tag' || (github.event_name == 'workflow_dispatch' && inputs.tag != '')
+        uses: DeterminateSystems/flakehub-push@main
+        with:
+          tag: ${{ inputs.tag || github.ref_name }}
+          visibility: ${{ inputs.visibility || 'public' }}
+          error-on-conflict: true
+
+      - name: Publish rolling release
+        if: github.event_name == 'workflow_dispatch' && inputs.rolling && inputs.tag == ''
+        uses: DeterminateSystems/flakehub-push@main
+        with:
+          rolling: true
+          visibility: ${{ inputs.visibility || 'public' }}

--- a/docs/artifacts.md
+++ b/docs/artifacts.md
@@ -45,6 +45,17 @@ nix build .#net-utils -L
 Downstream Home Manager users should consume the flake input and install
 `packages.${system}.darwin-nic`.
 
+The supported public flake reference remains:
+
+```bash
+nix run github:Jesssullivan/DarwinNicUtil -- status
+```
+
+FlakeHub publication is staged through the `Publish to FlakeHub` GitHub Actions
+workflow. Tagged releases publish from `v*.*.*` tags, and maintainers can run a
+manual rolling validation from the workflow dispatch form. Do not add FlakeHub
+install instructions to the README until a public FlakeHub release has completed.
+
 ## Documentation Site
 
 Build locally with:
@@ -69,7 +80,7 @@ GitHub Release.
 | PyPI | Planned through trusted publishing; tracked in [GitHub #11](https://github.com/Jesssullivan/DarwinNicUtil/issues/11) |
 | Standalone binary | PyInstaller spec exists, but binary releases are not validated yet; tracked in [GitHub #9](https://github.com/Jesssullivan/DarwinNicUtil/issues/9) |
 | Homebrew | Deferred; there is no active DarwinNicUtil tap/formula path until PyPI or standalone artifacts are proven, with the decision recorded in [GitHub #10](https://github.com/Jesssullivan/DarwinNicUtil/issues/10) |
-| FlakeHub | Existing Nix flake may be publishable, but FlakeHub is not advertised until proven; tracked in [GitHub #16](https://github.com/Jesssullivan/DarwinNicUtil/issues/16) |
+| FlakeHub | Publish workflow is staged for tag/manual validation, but FlakeHub is not advertised until a public release is proven; tracked in [GitHub #16](https://github.com/Jesssullivan/DarwinNicUtil/issues/16) |
 | Bazel / BCR | Not a primary install path; evaluate only if a real downstream Bazel/Bzlmod consumer needs it, tracked in [GitHub #17](https://github.com/Jesssullivan/DarwinNicUtil/issues/17) |
 | Container image | Not applicable for the CLI today |
 

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -115,6 +115,7 @@ def test_public_docs_stay_generic_and_release_accurate():
 def test_artifacts_docs_match_current_release_policy():
     artifacts = (REPO_ROOT / "docs" / "artifacts.md").read_text()
     readme = (REPO_ROOT / "README.md").read_text()
+    flakehub_workflow_path = REPO_ROOT / ".github" / "workflows" / "flakehub-publish.yml"
 
     assert "wheel/source distributions" in artifacts
     assert "Nix packages" in artifacts
@@ -122,7 +123,16 @@ def test_artifacts_docs_match_current_release_policy():
     assert "not validated yet" in artifacts
     assert "Homebrew | Deferred" in artifacts
     assert "no active DarwinNicUtil tap/formula path" in artifacts
+    assert "FlakeHub | Publish workflow is staged" in artifacts
+    assert "Do not add FlakeHub" in artifacts
+    assert "install instructions to the README" in artifacts
+    assert "nix run github:Jesssullivan/DarwinNicUtil -- status" in artifacts
+    assert "flakehub.com/f/" not in readme.lower()
     assert "PyPI publishing and standalone binary distribution remain tracked release" in readme
+
+    if flakehub_workflow_path.exists():
+        flakehub_workflow = flakehub_workflow_path.read_text()
+        assert "DeterminateSystems/flakehub-push@main" in flakehub_workflow
 
 
 def test_example_profile_networks_are_internally_consistent():


### PR DESCRIPTION
## Summary
- add a FlakeHub publish workflow with OIDC permissions, tag publishing, and guarded manual rolling publication
- document that GitHub flake references remain the supported public Nix path until FlakeHub is proven
- extend docs tests so FlakeHub is not advertised prematurely

Refs #16
Refs TIN-590

## Validation
- uv run --extra dev python -m pytest -q
- uv run --extra dev mkdocs build --strict
- just check
- nix flake check --print-build-logs
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/flakehub-publish.yml"); puts "workflow yaml ok"'