### PR TITLE
[codex] advertise proven FlakeHub release

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,14 +11,18 @@ path intact.
 
 - macOS is the primary supported platform.
 - Linux support is experimental and currently limited.
-- Release artifacts are source distributions, wheels, and Nix packages.
+- Release artifacts are source distributions, wheels, Nix packages, and
+  FlakeHub releases.
 - The PyInstaller spec is retained for manual builds, but standalone binaries
   are not the primary release artifact yet.
 
 ## Quick Start
 
 ```bash
-# Run from Nix without cloning
+# Run the stable v2.1.0 release from FlakeHub
+nix run "https://flakehub.com/f/Jesssullivan/DarwinNicUtil/v2.1.0" -- status
+
+# Or run directly from GitHub
 nix run github:Jesssullivan/DarwinNicUtil -- status
 nix run github:Jesssullivan/DarwinNicUtil -- configure \
   --device-ip <device-ipv4> \
@@ -47,7 +51,10 @@ darwin-nic configure --profile homelab --preserve-wifi
 ## Install
 
 ```bash
-# Nix profile
+# Nix profile from FlakeHub
+nix profile install "https://flakehub.com/f/Jesssullivan/DarwinNicUtil/v2.1.0"
+
+# Nix profile from GitHub
 nix profile install github:Jesssullivan/DarwinNicUtil
 
 # uv from source
@@ -150,9 +157,9 @@ Run `just` with no arguments to see all recipes.
 Current release artifacts are:
 
 - Python wheel and source distribution from `uv build`;
-- Nix flake package outputs;
+- Nix flake package outputs, including FlakeHub `v2.1.0`;
 - MkDocs site artifacts from the docs workflow.
 
-GitHub release and docs workflows are present for tag-based publication.
-PyPI publishing and standalone binary distribution remain tracked release
-follow-ups.
+GitHub release, FlakeHub, and docs workflows are present for tag-based
+publication. PyPI publishing and standalone binary distribution remain tracked
+release follow-ups.

--- a/docs/artifacts.md
+++ b/docs/artifacts.md
@@ -1,7 +1,7 @@
 # Artifacts
 
-This project currently treats wheel/source distributions, Nix packages, and the
-MkDocs site as release artifacts.
+This project currently treats wheel/source distributions, Nix packages,
+FlakeHub releases, and the MkDocs site as release artifacts.
 
 ## Python Packages
 
@@ -45,16 +45,22 @@ nix build .#net-utils -L
 Downstream Home Manager users should consume the flake input and install
 `packages.${system}.darwin-nic`.
 
-The supported public flake reference remains:
+The stable FlakeHub release reference is:
+
+```bash
+nix run "https://flakehub.com/f/Jesssullivan/DarwinNicUtil/v2.1.0" -- status
+```
+
+The direct GitHub flake reference remains supported:
 
 ```bash
 nix run github:Jesssullivan/DarwinNicUtil -- status
 ```
 
-FlakeHub publication is staged through the `Publish to FlakeHub` GitHub Actions
+FlakeHub publication runs through the `Publish to FlakeHub` GitHub Actions
 workflow. Tagged releases publish from `v*.*.*` tags, and maintainers can run a
-manual rolling validation from the workflow dispatch form. Do not add FlakeHub
-install instructions to the README until a public FlakeHub release has completed.
+manual rolling validation from the workflow dispatch form. The current public
+FlakeHub releases are `v2.1.0` and the rolling `*` channel.
 
 ## Documentation Site
 
@@ -80,11 +86,10 @@ GitHub Release.
 | PyPI | Planned through trusted publishing; tracked in [GitHub #11](https://github.com/Jesssullivan/DarwinNicUtil/issues/11) |
 | Standalone binary | PyInstaller spec exists, but binary releases are not validated yet; tracked in [GitHub #9](https://github.com/Jesssullivan/DarwinNicUtil/issues/9) |
 | Homebrew | Deferred; there is no active DarwinNicUtil tap/formula path until PyPI or standalone artifacts are proven, with the decision recorded in [GitHub #10](https://github.com/Jesssullivan/DarwinNicUtil/issues/10) |
-| FlakeHub | Publish workflow is staged for tag/manual validation, but FlakeHub is not advertised until a public release is proven; tracked in [GitHub #16](https://github.com/Jesssullivan/DarwinNicUtil/issues/16) |
 | Bazel / BCR | Not a primary install path; evaluate only if a real downstream Bazel/Bzlmod consumer needs it, tracked in [GitHub #17](https://github.com/Jesssullivan/DarwinNicUtil/issues/17) |
 | Container image | Not applicable for the CLI today |
 
-FlakeHub and Bazel/BCR work should stay aligned with the broader Tinyland
-distribution substrate. Homebrew should be reconsidered only after a supported
-PyPI or standalone artifact exists. This repo should only document public,
-validated install paths.
+Bazel/BCR work should stay aligned with the broader Tinyland distribution
+substrate. Homebrew should be reconsidered only after a supported PyPI or
+standalone artifact exists. This repo should only document public, validated
+install paths.

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,6 +18,10 @@ belong in downstream operator repositories.
 ## Quick Start
 
 ```bash
+# Stable release from FlakeHub
+nix run "https://flakehub.com/f/Jesssullivan/DarwinNicUtil/v2.1.0" -- status
+
+# Direct GitHub flake reference
 nix run github:Jesssullivan/DarwinNicUtil -- status
 nix run github:Jesssullivan/DarwinNicUtil -- configure \
   --device-ip 192.168.88.1 \
@@ -65,5 +69,5 @@ flowchart LR
 ## Artifacts
 
 The release path currently supports Python wheel/source distributions, Nix
-packages, and MkDocs site artifacts. Standalone binary and PyPI publication are
-tracked follow-ups rather than established release outputs.
+packages, FlakeHub releases, and MkDocs site artifacts. Standalone binary and
+PyPI publication are tracked follow-ups rather than established release outputs.

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -9,7 +9,8 @@ Primary docs:
 - `docs/quickstart.md`: current Nix, source, and uv tool startup flows.
 - `docs/cli.md`: command and option reference.
 - `docs/bastion.md`: generic bastion/OOB operator flow and boundaries.
-- `docs/artifacts.md`: current release artifact policy.
+- `docs/artifacts.md`: current release artifact policy, including GitHub
+  Releases and FlakeHub.
 - `docs/architecture.md`: module structure and safety architecture.
 - `docs/superpowers/release-sprint-plan.md`: release-readiness sprint plan.
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -7,8 +7,10 @@ Get a USB management NIC configured without letting it take over normal Wi-Fi or
 === "Nix"
 
     ```bash
-    nix run github:Jesssullivan/DarwinNicUtil -- setup
+    # Stable release
+    nix run "https://flakehub.com/f/Jesssullivan/DarwinNicUtil/v2.1.0" -- setup
 
+    # Direct GitHub flake reference
     nix run github:Jesssullivan/DarwinNicUtil -- configure \
       --device-ip 192.168.88.1 \
       --laptop-ip 192.168.88.100 \

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -123,12 +123,13 @@ def test_artifacts_docs_match_current_release_policy():
     assert "not validated yet" in artifacts
     assert "Homebrew | Deferred" in artifacts
     assert "no active DarwinNicUtil tap/formula path" in artifacts
-    assert "FlakeHub | Publish workflow is staged" in artifacts
-    assert "Do not add FlakeHub" in artifacts
-    assert "install instructions to the README" in artifacts
+    assert "FlakeHub releases" in artifacts
+    assert "https://flakehub.com/f/Jesssullivan/DarwinNicUtil/v2.1.0" in artifacts
+    assert "current public" in artifacts
+    assert "FlakeHub releases are `v2.1.0`" in artifacts
     assert "nix run github:Jesssullivan/DarwinNicUtil -- status" in artifacts
-    assert "flakehub.com/f/" not in readme.lower()
-    assert "PyPI publishing and standalone binary distribution remain tracked release" in readme
+    assert "https://flakehub.com/f/Jesssullivan/DarwinNicUtil/v2.1.0" in readme
+    assert "PyPI publishing and standalone binary distribution remain tracked" in readme
 
     if flakehub_workflow_path.exists():
         flakehub_workflow = flakehub_workflow_path.read_text()


### PR DESCRIPTION
## Summary
- document the public FlakeHub v2.1.0 release in README, quickstart, docs home, artifacts, and llms context
- keep direct GitHub flake refs supported
- update docs tests to guard the proven FlakeHub artifact surface

Refs #16
Refs TIN-590

## Validation
- nix run "https://flakehub.com/f/Jesssullivan/DarwinNicUtil/v2.1.0" -- --version
- nix flake show "https://flakehub.com/f/Jesssullivan/DarwinNicUtil/v2.1.0" --no-write-lock-file
- uv run --extra dev python -m pytest -q
- uv run --extra dev mkdocs build --strict
- just check
- nix flake check --print-build-logs

## FlakeHub proof
- Rolling run: https://github.com/Jesssullivan/DarwinNicUtil/actions/runs/24936453995
- Tagged v2.1.0 run: https://github.com/Jesssullivan/DarwinNicUtil/actions/runs/24936500275
- Release API: https://api.flakehub.com/f/Jesssullivan/DarwinNicUtil/releases