### PR TITLE
[codex] record Bazel packaging decision

### DIFF
--- a/docs/artifacts.md
+++ b/docs/artifacts.md
@@ -89,6 +89,25 @@ GitHub Release.
 | Bazel / BCR | Not a primary install path; evaluate only if a real downstream Bazel/Bzlmod consumer needs it, tracked in [GitHub #17](https://github.com/Jesssullivan/DarwinNicUtil/issues/17) |
 | Container image | Not applicable for the CLI today |
 
+## Bazel / BCR Decision
+
+DarwinNicUtil does not ship a Bazel or Bzlmod module today. The validated
+distribution paths are Python wheel/source distributions, GitHub Releases, Nix
+flake references, and FlakeHub releases.
+
+Do not introduce Bazel as a default local build, test, or install path for this
+repo. Current repo and sibling-repo evidence does not show a downstream
+`MODULE.bazel` or `BUILD.bazel` consumer for DarwinNicUtil.
+
+If a real downstream Bazel consumer appears, keep the surface minimal:
+
+- add only the `MODULE.bazel` metadata and targets needed by that consumer;
+- prefer consuming an existing wheel, source distribution, or FlakeHub/GitHub
+  source archive over recreating the primary packaging pipeline in Bazel;
+- align any BCR work with Tinyland's existing cache-backed conventions;
+- keep README and quickstart docs focused on uv, wheel/source, Nix, and
+  FlakeHub unless the Bazel path becomes a validated public artifact.
+
 Bazel/BCR work should stay aligned with the broader Tinyland distribution
 substrate. Homebrew should be reconsidered only after a supported PyPI or
 standalone artifact exists. This repo should only document public, validated

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -123,6 +123,10 @@ def test_artifacts_docs_match_current_release_policy():
     assert "not validated yet" in artifacts
     assert "Homebrew | Deferred" in artifacts
     assert "no active DarwinNicUtil tap/formula path" in artifacts
+    assert "DarwinNicUtil does not ship a Bazel or Bzlmod module today" in artifacts
+    assert "does not show a downstream" in artifacts
+    assert "`MODULE.bazel` or `BUILD.bazel` consumer" in artifacts
+    assert "Do not introduce Bazel as a default local build" in artifacts
     assert "FlakeHub releases" in artifacts
     assert "https://flakehub.com/f/Jesssullivan/DarwinNicUtil/v2.1.0" in artifacts
     assert "current public" in artifacts


### PR DESCRIPTION
## Summary
- record that DarwinNicUtil should not ship Bazel/Bzlmod metadata today
- keep Bazel/BCR out of the primary install story until a real downstream consumer appears
- add docs tests that guard the no-primary-Bazel decision

Refs #17
Refs TIN-591

## Evidence
- Current repo and sibling `MODULE.bazel` / `BUILD.bazel` files do not reference DarwinNicUtil.
- Existing validated artifacts are wheel/source, GitHub Releases, Nix flake references, and FlakeHub releases.
- Tinyland BCR context exists, but no DarwinNicUtil consumer requires a Bazel module today.

## Validation
- uv run --extra dev python -m pytest tests/test_docs.py -q
- uv run --extra dev python -m pytest -q
- uv run --extra dev mkdocs build --strict
- just check