### PR TITLE
[codex] stage PyPI trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ on:
         type: string
 
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -22,6 +22,8 @@ jobs:
   build:
     name: Build release artifacts
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -70,3 +72,26 @@ jobs:
           files: |
             dist/*.whl
             dist/*.tar.gz
+
+  publish-pypi:
+    name: Publish to PyPI
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    needs: build
+    environment:
+      name: pypi
+      url: https://pypi.org/project/darwin-mgmt-nic-configurator/
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Download distributions
+        uses: actions/download-artifact@v8
+        with:
+          name: python-dist
+          path: dist/
+
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          print-hash: true

--- a/README.md
+++ b/README.md
@@ -161,5 +161,6 @@ Current release artifacts are:
 - MkDocs site artifacts from the docs workflow.
 
 GitHub release, FlakeHub, and docs workflows are present for tag-based
-publication. PyPI publishing and standalone binary distribution remain tracked
-release follow-ups.
+publication. The PyPI trusted-publishing workflow is staged but not documented
+as an install path until the first upload is validated. Standalone binary
+distribution remains a tracked release follow-up.

--- a/docs/artifacts.md
+++ b/docs/artifacts.md
@@ -79,11 +79,31 @@ The release workflow runs on tags matching `v*.*.*`. It builds the Python
 distribution files and attaches only the wheel and source distribution to the
 GitHub Release.
 
+## PyPI Trusted Publishing
+
+PyPI publication is staged in the release workflow, but it is not a supported
+install path until the first trusted-publishing upload succeeds.
+
+The package name planned for PyPI is `darwin-mgmt-nic-configurator`. Configure
+a PyPI pending publisher before pushing the first PyPI-enabled release tag:
+
+| Field | Value |
+|-------|-------|
+| Owner | `Jesssullivan` |
+| Repository | `DarwinNicUtil` |
+| Workflow | `release.yml` |
+| Environment | `pypi` |
+
+The release workflow uses GitHub OIDC with `pypa/gh-action-pypi-publish` and
+does not use a stored PyPI API token. Keep README and quickstart install
+commands focused on Nix, FlakeHub, wheel/source, and source checkout paths
+until a real PyPI upload is validated.
+
 ## Not Yet Primary Artifacts
 
 | Surface | Current status |
 |---------|----------------|
-| PyPI | Planned through trusted publishing; tracked in [GitHub #11](https://github.com/Jesssullivan/DarwinNicUtil/issues/11) |
+| PyPI | Trusted-publishing workflow is staged; install docs remain pending until first upload is validated, tracked in [GitHub #11](https://github.com/Jesssullivan/DarwinNicUtil/issues/11) |
 | Standalone binary | PyInstaller spec exists, but binary releases are not validated yet; tracked in [GitHub #9](https://github.com/Jesssullivan/DarwinNicUtil/issues/9) |
 | Homebrew | Deferred; there is no active DarwinNicUtil tap/formula path until PyPI or standalone artifacts are proven, with the decision recorded in [GitHub #10](https://github.com/Jesssullivan/DarwinNicUtil/issues/10) |
 | Bazel / BCR | Not a primary install path; evaluate only if a real downstream Bazel/Bzlmod consumer needs it, tracked in [GitHub #17](https://github.com/Jesssullivan/DarwinNicUtil/issues/17) |

--- a/docs/development.md
+++ b/docs/development.md
@@ -89,7 +89,7 @@ GitHub Actions now own the public validation path:
 | `ci.yml` | Format, lint, type-check, tests, docs build, package build |
 | `secret-detection.yml` | Gitleaks and TruffleHog scanning |
 | `docs.yml` | MkDocs build and GitHub Pages artifact upload |
-| `release.yml` | Tag-triggered wheel/source distribution and GitHub Release |
+| `release.yml` | Tag-triggered wheel/source distribution, GitHub Release, and staged PyPI publish |
 
 GitLab CI remains in the repository for compatibility, but GitHub is the
 release-facing surface.
@@ -114,6 +114,7 @@ git push origin v2.1.0
 ```
 
 The release workflow attaches only wheel and source distribution files from
-`dist/` to the GitHub Release. PyPI trusted publishing and standalone binary
-distribution are follow-up release tasks unless they are explicitly enabled
-before the tag.
+`dist/` to the GitHub Release. It also contains the PyPI trusted-publishing job
+for tag builds; configure the PyPI pending publisher for
+`release.yml`/`pypi` before relying on it. Standalone binary distribution
+remains a follow-up release task.

--- a/docs/index.md
+++ b/docs/index.md
@@ -69,5 +69,6 @@ flowchart LR
 ## Artifacts
 
 The release path currently supports Python wheel/source distributions, Nix
-packages, FlakeHub releases, and MkDocs site artifacts. Standalone binary and
-PyPI publication are tracked follow-ups rather than established release outputs.
+packages, FlakeHub releases, and MkDocs site artifacts. The PyPI publish job is
+staged behind trusted publishing, but PyPI install docs wait for the first
+validated upload. Standalone binary publication remains a tracked follow-up.

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -133,11 +133,33 @@ def test_artifacts_docs_match_current_release_policy():
     assert "FlakeHub releases are `v2.1.0`" in artifacts
     assert "nix run github:Jesssullivan/DarwinNicUtil -- status" in artifacts
     assert "https://flakehub.com/f/Jesssullivan/DarwinNicUtil/v2.1.0" in readme
-    assert "PyPI publishing and standalone binary distribution remain tracked" in readme
+    assert "PyPI trusted-publishing workflow is staged" in readme
+    assert "not documented" in readme
+    assert "until the first upload is validated" in readme
 
     if flakehub_workflow_path.exists():
         flakehub_workflow = flakehub_workflow_path.read_text()
         assert "DeterminateSystems/flakehub-push@main" in flakehub_workflow
+
+
+def test_pypi_publish_surface_is_staged_but_not_overclaimed():
+    artifacts = (REPO_ROOT / "docs" / "artifacts.md").read_text()
+    release_workflow = (REPO_ROOT / ".github" / "workflows" / "release.yml").read_text()
+    readme = (REPO_ROOT / "README.md").read_text()
+    quickstart = (REPO_ROOT / "docs" / "quickstart.md").read_text()
+
+    assert "PyPI Trusted Publishing" in artifacts
+    assert "darwin-mgmt-nic-configurator" in artifacts
+    assert "release.yml" in artifacts
+    assert "`pypi`" in artifacts
+    assert "pypa/gh-action-pypi-publish@release/v1" in release_workflow
+    assert "id-token: write" in release_workflow
+    assert "environment:" in release_workflow
+    assert "name: pypi" in release_workflow
+    assert "username:" not in release_workflow
+    assert "password:" not in release_workflow
+    assert "pipx install darwin-mgmt-nic-configurator" not in readme
+    assert "pipx install darwin-mgmt-nic-configurator" not in quickstart
 
 
 def test_example_profile_networks_are_internally_consistent():


### PR DESCRIPTION
## Summary

- add a tag-only PyPI publish job to the release workflow using GitHub OIDC and `pypa/gh-action-pypi-publish`
- document the exact pending publisher settings for PyPI: owner, repo, workflow, and `pypi` environment
- keep README/quickstart conservative until the first real PyPI upload is validated
- add docs tests so the repo does not overclaim PyPI as an install path before publication works

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "release workflow yaml ok"'`\n- `uv run --extra dev python -m pytest tests/test_docs.py -q`\n- `uv run --extra dev python -m pytest -q`\n- `uv run --extra dev mkdocs build --strict`\n- `just check`\n- `git diff --check`\n\nTracks #11 / TIN-582.