### PR TITLE
Ratchet coverage gate to 50 percent

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -52,8 +52,8 @@ uv build
 ## Test Policy
 
 Runtime changes should include focused tests near the touched surface. The
-current coverage gate starts at 40 percent and should ratchet upward as the
-large TUI and network-manager surfaces become better covered.
+current coverage gate is 50 percent and should ratchet upward as the large
+guided-setup surface becomes better covered.
 
 Useful focused runs:
 

--- a/docs/superpowers/release-sprint-plan.md
+++ b/docs/superpowers/release-sprint-plan.md
@@ -22,7 +22,7 @@ site-specific recovery policy remain outside this repository.
 
 | Surface | Status |
 |---------|--------|
-| Tests | Unit suite is green with coverage above the configured 40 percent gate |
+| Tests | Unit suite is green with coverage above the configured 50 percent gate |
 | CI | GitHub Actions now cover CI, docs, secret scans, and tag releases |
 | Docs | MkDocs includes quickstart, architecture, CLI, bastion, artifacts, and this plan |
 | Packaging | Wheel/source distribution and Nix package paths are present |
@@ -71,7 +71,7 @@ device names, policies, and secrets.
 | P0 | Nix validation | `nix flake check` passes with new docs and tests included |
 | P0 | Hardware dry-run | `darwin-nic status` and `configure --dry-run` are checked on a bastion Mac |
 | P1 | Close or split issue #4 | Shipped NECP diagnostics are documented; remaining hardware evidence is tracked |
-| P1 | Ratchet tests | Next target is 50 percent coverage after macOS/network-manager follow-ups |
+| P1 | Ratchet tests | 50 percent coverage gate is enforced; next target is guided-setup behavior |
 | P2 | PyPI trusted publishing | Trusted publisher is configured and release workflow publishes packages |
 | P2 | Binary installer decision | Either validate PyInstaller releases or document them as unsupported |
 | P3 | Sophos and ABR spikes | Issues #2 and #3 are scoped separately from v2.1.0 release readiness |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,7 +125,7 @@ omit = [
 ]
 
 [tool.coverage.report]
-fail_under = 40
+fail_under = 50
 exclude_lines = [
     "pragma: no cover",
     "def __repr__",

--- a/src/darwin_mgmt_nic/tui.py
+++ b/src/darwin_mgmt_nic/tui.py
@@ -7,6 +7,8 @@ Uses Rich's Layout and Live to create a proper terminal application.
 Uses alternate screen mode (like vim/emacs) - exits cleanly back to shell.
 """
 
+from __future__ import annotations
+
 import itertools
 import shutil
 import signal

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -167,6 +167,17 @@ def test_pypi_publish_surface_is_staged_but_not_overclaimed():
     assert "pipx install darwin-mgmt-nic-configurator" not in quickstart
 
 
+def test_coverage_gate_is_ratchet_to_fifty_percent():
+    pyproject = (REPO_ROOT / "pyproject.toml").read_text()
+    development = (REPO_ROOT / "docs" / "development.md").read_text()
+    release_plan = (REPO_ROOT / "docs" / "superpowers" / "release-sprint-plan.md").read_text()
+
+    assert "fail_under = 50" in pyproject
+    assert "current coverage gate is 50 percent" in development
+    assert "configured 50 percent gate" in release_plan
+    assert "configured 40 percent gate" not in release_plan
+
+
 def test_root_entrypoint_uses_package_app_version():
     script = (REPO_ROOT / "darwin-nic").read_text()
     backend_cli = (REPO_ROOT / "src" / "darwin_mgmt_nic" / "cli.py").read_text()

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -1,0 +1,156 @@
+"""
+Tests for TUI state helpers and keyboard-driven control flow.
+"""
+
+from collections.abc import Iterable
+
+import pytest
+from rich.console import Console
+from rich.text import Text
+
+from darwin_mgmt_nic import tui
+
+
+def make_console() -> Console:
+    return Console(force_terminal=True, width=100, height=30, record=True)
+
+
+def key_reader(keys: Iterable[str]):
+    iterator = iter(keys)
+    return lambda: next(iterator)
+
+
+class TestProgressAndSpinner:
+    def test_progress_indicator_clamps_step_and_renders_labels(self):
+        progress = tui.ProgressIndicator()
+
+        progress.set_step(-10)
+        assert progress.current == 0
+        assert "Baseline" in str(progress.render())
+
+        progress.set_step(999)
+        assert progress.current == len(progress.STEPS) - 1
+        rendered = str(progress.render())
+        assert "Done" in rendered
+        assert "Baseline" in rendered
+
+    def test_spinner_render_tracks_active_and_ready_states(self):
+        spinner = tui.SpinnerState()
+
+        assert "Ready" in str(spinner.render())
+
+        spinner.set("Scanning interfaces")
+        first = str(spinner.render())
+        second = str(spinner.render())
+
+        assert "Scanning interfaces" in first
+        assert "Scanning interfaces" in second
+        assert first != second
+
+        spinner.clear()
+        assert "Ready" in str(spinner.render())
+
+
+class TestLayout:
+    def test_layout_updates_regions_and_resizes(self, monkeypatch):
+        sizes = iter([(100, 30), (72, 22)])
+        monkeypatch.setattr(tui, "get_terminal_size", lambda: next(sizes))
+
+        layout = tui.TUILayout(make_console())
+
+        assert layout.layout["header"].name == "header"
+        assert layout.layout["progress"].name == "progress"
+        assert layout.layout["body"].name == "body"
+        assert layout.layout["status"].name == "status"
+
+        layout.update_step(3, "Cable Check")
+        assert layout.progress.current == 2
+        assert layout._step_title == "Cable Check"
+
+        body = Text("Body content")
+        layout.update_body(body)
+        assert layout._body_content is body
+
+        layout.update_status("Working", spinner=True)
+        assert layout.spinner.active is True
+        assert layout.spinner.message == "Working"
+
+        layout.show_error("Failure", "Details")
+        layout.show_success("Recovered", "Done")
+        layout.resize()
+
+        assert layout._width == 72
+        assert layout._height == 22
+        assert layout.get_layout() is layout.layout
+
+
+class TestAppControlFlow:
+    def test_terminal_size_check_reports_small_and_acceptable_sizes(self, monkeypatch):
+        monkeypatch.setattr(tui, "get_terminal_size", lambda: (40, 10))
+        app = tui.TUIApp(make_console())
+
+        ok, message = app.check_terminal_size()
+
+        assert ok is False
+        assert "Terminal too small" in message
+
+        monkeypatch.setattr(tui, "get_terminal_size", lambda: (100, 30))
+
+        ok, message = app.check_terminal_size()
+
+        assert ok is True
+        assert message == ""
+
+    def test_confirm_handles_yes_no_defaults_and_interrupts(self, monkeypatch):
+        monkeypatch.setattr(tui, "get_terminal_size", lambda: (100, 30))
+        app = tui.TUIApp(make_console())
+
+        monkeypatch.setattr(tui, "read_single_key", key_reader(["x", "y"]))
+        assert app.confirm("Continue?") is True
+
+        monkeypatch.setattr(tui, "read_single_key", key_reader(["n"]))
+        assert app.confirm("Continue?", default=True) is False
+
+        monkeypatch.setattr(tui, "read_single_key", key_reader(["\n"]))
+        assert app.confirm("Continue?", default=True) is True
+
+        monkeypatch.setattr(tui, "read_single_key", key_reader(["q"]))
+        with pytest.raises(KeyboardInterrupt):
+            app.confirm("Continue?")
+
+    def test_prompt_text_supports_editing_default_and_cancel(self, monkeypatch):
+        monkeypatch.setattr(tui, "get_terminal_size", lambda: (100, 30))
+        app = tui.TUIApp(make_console())
+
+        monkeypatch.setattr(tui, "read_single_key", key_reader(["a", "b", "\x7f", "c", "\n"]))
+        assert app.prompt_text("Name") == "ac"
+
+        monkeypatch.setattr(tui, "read_single_key", key_reader(["x", "\x15", "z", "\n"]))
+        assert app.prompt_text("Name") == "z"
+
+        monkeypatch.setattr(tui, "read_single_key", key_reader(["\x1b"]))
+        assert app.prompt_text("Name", default="fallback") == "fallback"
+
+    def test_wait_for_key_and_spinner_helper(self, monkeypatch):
+        monkeypatch.setattr(tui, "get_terminal_size", lambda: (100, 30))
+        app = tui.TUIApp(make_console())
+
+        monkeypatch.setattr(tui, "read_single_key", key_reader(["k"]))
+        assert app.wait_for_key() == "k"
+
+        assert app.run_with_spinner("Working", lambda value: value * 2, 4) == 8
+        assert app.tui.spinner.active is False
+
+        monkeypatch.setattr(tui, "read_single_key", key_reader(["\x03"]))
+        with pytest.raises(KeyboardInterrupt):
+            app.wait_for_key()
+
+
+def test_build_content_converts_strings_and_keeps_renderables():
+    marker = Text("Existing")
+    content = tui.build_content("plain", marker)
+
+    assert len(content.renderables) == 2
+    assert isinstance(content.renderables[0], Text)
+    assert str(content.renderables[0]) == "plain"
+    assert content.renderables[1] is marker


### PR DESCRIPTION
## Summary

- add focused TUI tests for progress/spinner state, layout updates, prompt control flow, and content construction
- raise coverage from 48.44% baseline to 55.88%
- ratchet `[tool.coverage.report].fail_under` from 40 to 50
- update development/release-plan docs and add a docs guard for the new threshold

## Validation

- `uv run --extra dev python -m pytest tests/test_tui.py -q`
- `uv run --extra dev python -m pytest tests/test_docs.py tests/test_tui.py -q`
- `uv run --extra dev python -m pytest --cov=darwin_mgmt_nic --cov-report=term-missing --tb=short -q`
- `uv run --extra dev python -m pytest -q`
- `uv run --extra dev mkdocs build --strict`
- `just check`
- `git diff --check`

Coverage result: 55.88%, with the new 50% gate enforced.

Tracks #12 / TIN-585.