### PR TITLE
Draft public project spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ uv tool install .
 ```
 
 Home Manager and System Manager modules are available under `nix/modules/`.
+For the release shape and productionization summary, see
+[`docs/project-spec.md`](docs/project-spec.md).
 
 ## Commands
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,6 +15,9 @@ preserving the host's normal Wi-Fi and tailnet path.
 Device-specific topology, credentials, switch commands, and recovery policy
 belong in downstream operator repositories.
 
+For the public release shape and productionization summary, see the
+[project spec](project-spec.md).
+
 ## Quick Start
 
 ```bash

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -11,6 +11,7 @@ Primary docs:
 - `docs/bastion.md`: generic bastion/OOB operator flow and boundaries.
 - `docs/artifacts.md`: current release artifact policy, including GitHub
   Releases and FlakeHub.
+- `docs/project-spec.md`: public project spec and productionization summary.
 - `docs/architecture.md`: module structure and safety architecture.
 - `docs/superpowers/release-sprint-plan.md`: release-readiness sprint plan.
 

--- a/docs/project-spec.md
+++ b/docs/project-spec.md
@@ -1,0 +1,112 @@
+# Project Spec
+
+DarwinNicUtil is a small operator tool for one recurring network-management
+problem: a workstation needs a temporary USB Ethernet management link without
+losing its normal Wi-Fi, VPN, or tailnet path.
+
+The v2.1 productionization work turns the repo from a useful local script into
+a release-ready package with documented boundaries, repeatable artifacts, and
+CI-backed safety checks.
+
+## Problem
+
+USB management adapters are convenient for bench and bastion workflows, but
+host network policy can make them confusing:
+
+- a USB NIC can outrank Wi-Fi and disrupt the operator's primary path;
+- route state can look correct while host-local policy still blocks ordinary
+  sockets;
+- link-layer tools can work while TCP clients fail;
+- one-off shell fixes are hard to repeat safely across machines.
+
+`darwin-nic` makes the host-side setup explicit and inspectable.
+
+## Goals
+
+- Detect and rank safe USB NIC candidates.
+- Configure a static management address and route.
+- Preserve Wi-Fi and tailnet reachability by default.
+- Support profile-driven repeated use.
+- Show dry-run and status output before privileged changes.
+- Surface macOS bastion diagnostics for route state, `scutil --nwi`,
+  Tailscale system-extension state, and recent NECP socket-drop hints.
+- Keep downstream device policy out of this generic tool.
+
+## Non-Goals
+
+- Storing credentials.
+- Running device-specific recovery commands.
+- Encoding switch hostnames, MAC addresses, or topology.
+- Replacing downstream operator runbooks.
+- Promising standalone binaries before CI, checksums, and signing policy exist.
+
+## Operator Contract
+
+The stable generic commands are:
+
+```bash
+darwin-nic status
+darwin-nic configure --profile homelab --preserve-wifi
+```
+
+Profiles are TOML and intentionally portable:
+
+```toml
+default_profile = "homelab"
+
+[defaults]
+preserve_wifi = true
+
+[profiles.homelab]
+device_ip = "192.168.88.1"
+laptop_ip = "192.168.88.100"
+mgmt_network = "192.168.88.0/24"
+device_name = "Lab Management Device"
+device_type = "network"
+```
+
+The example values are documentation values for a generic management subnet.
+Consumers own their own device names, secrets, and recovery policy.
+
+## Release Surfaces
+
+Current validated surfaces:
+
+- GitHub Release with wheel and source distribution artifacts.
+- Nix flake package outputs.
+- FlakeHub release `v2.1.0` and rolling channel.
+- MkDocs site published by GitHub Pages.
+
+Staged or deferred surfaces:
+
+- PyPI trusted publishing is staged in the release workflow, pending PyPI-side
+  publisher setup and a validated first upload.
+- Standalone binaries are local smoke-test artifacts only until CI builds,
+  tests, checksums, and signing/notarization policy exist.
+- Homebrew is deferred until PyPI or standalone binary artifacts are proven.
+- Bazel/Bzlmod is not a primary install path unless a real downstream consumer
+  appears.
+
+## Productionization Results
+
+The post-v2.1 hardening pass added:
+
+- GitHub Actions for Python checks, docs, Nix, release artifacts, and secret
+  scanning.
+- Gitleaks and TruffleHog CI surfaces.
+- MkDocs pages for quickstart, bastion/OOB flow, architecture, artifacts, CLI,
+  and development.
+- Agent-facing docs in `AGENTS.md` and `docs/llms.txt`.
+- FlakeHub publication workflow and documented release reference.
+- PyPI trusted-publishing workflow staging.
+- Explicit artifact policy for PyPI, binaries, Homebrew, and Bazel/BCR.
+- Coverage gate ratcheted to 50 percent, with current coverage above 55
+  percent.
+
+## Next Work
+
+- Complete PyPI publication after creating the pending publisher.
+- Draft a longer external blog post only if there is a maintained public venue.
+- Add guided-setup behavior tests before the next coverage ratchet.
+- Keep Sophos and ABR ideas as separate boundary spikes until they have a
+  generic, non-secret, non-device-specific shape.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -53,6 +53,7 @@ nav:
   - Quick Start: quickstart.md
   - Bastion / OOB: bastion.md
   - Artifacts: artifacts.md
+  - Project Spec: project-spec.md
   - Architecture: architecture.md
   - CLI Reference: cli.md
   - Development: development.md

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -20,6 +20,7 @@ def test_operator_docs_do_not_point_at_retired_gitlab_repository():
         REPO_ROOT / "docs" / "cli.md",
         REPO_ROOT / "docs" / "development.md",
         REPO_ROOT / "docs" / "index.md",
+        REPO_ROOT / "docs" / "project-spec.md",
         REPO_ROOT / "docs" / "quickstart.md",
         REPO_ROOT / "docs" / "llms.txt",
         REPO_ROOT / "mkdocs.yml",
@@ -88,6 +89,7 @@ def test_public_docs_stay_generic_and_release_accurate():
         REPO_ROOT / "docs" / "cli.md",
         REPO_ROOT / "docs" / "development.md",
         REPO_ROOT / "docs" / "index.md",
+        REPO_ROOT / "docs" / "project-spec.md",
         REPO_ROOT / "docs" / "quickstart.md",
         REPO_ROOT / "docs" / "superpowers" / "release-sprint-plan.md",
         REPO_ROOT / "examples" / "config.toml",
@@ -176,6 +178,33 @@ def test_coverage_gate_is_ratchet_to_fifty_percent():
     assert "current coverage gate is 50 percent" in development
     assert "configured 50 percent gate" in release_plan
     assert "configured 40 percent gate" not in release_plan
+
+
+def test_project_spec_is_public_and_generic():
+    readme = (REPO_ROOT / "README.md").read_text()
+    index = (REPO_ROOT / "docs" / "index.md").read_text()
+    mkdocs = (REPO_ROOT / "mkdocs.yml").read_text()
+    llms = (REPO_ROOT / "docs" / "llms.txt").read_text()
+    spec = (REPO_ROOT / "docs" / "project-spec.md").read_text()
+
+    assert "[`docs/project-spec.md`](docs/project-spec.md)" in readme
+    assert "[project spec](project-spec.md)" in index
+    assert "Project Spec: project-spec.md" in mkdocs
+    assert "docs/project-spec.md" in llms
+    assert "Productionization Results" in spec
+    assert "PyPI trusted publishing is staged" in spec
+    assert "Coverage gate ratcheted to 50 percent" in spec
+    assert "Consumers own their own device names, secrets, and recovery policy" in spec
+
+    forbidden = [
+        "crs309-main",
+        "vault_mikrotik_password",
+        "sops-nix/secrets",
+        "100.111.",
+        "100.124.",
+    ]
+    for phrase in forbidden:
+        assert phrase not in spec
 
 
 def test_root_entrypoint_uses_package_app_version():


### PR DESCRIPTION
## Summary

- add `docs/project-spec.md` as a concise public project spec and productionization summary
- add the page to MkDocs navigation and the maintained docs index surfaces
- link the spec from README now that it lives in the published docs set
- add docs tests that enforce the link surface and prevent private topology/secret details from entering the spec

## Validation

- `uv run --extra dev python -m pytest tests/test_docs.py -q`
- `uv run --extra dev mkdocs build --strict`
- `uv run --extra dev python -m pytest -q`
- `just check`
- `git diff --check`

Tracks #14 / TIN-587.