### PR TITLE
Document ABR and Sophos boundary decisions

### DIFF
--- a/docs/project-spec.md
+++ b/docs/project-spec.md
@@ -40,6 +40,24 @@ host network policy can make them confusing:
 - Replacing downstream operator runbooks.
 - Promising standalone binaries before CI, checksums, and signing policy exist.
 
+## Boundary Decisions
+
+DarwinNicUtil can report generic host-side conditions that affect a USB
+management NIC, but it should not become a compliance, endpoint-security, or
+approval-bypass tool.
+
+ABR-style approval keepalives and scripted approvers are out of scope for this
+repo. If a site needs that behavior, it belongs in local operator automation or
+a separate tool with its own security review. The generic contract here remains
+normal interactive sudo for CLI use, TUI-safe sudo after pre-authentication, and
+clear dry-run/status output before privileged changes.
+
+Sophos, ZTNA, CryptoGuard, and similar endpoint-security products are also out
+of scope as product-specific integrations. This repo may document generic
+symptoms such as host-local socket policy blocking ordinary TCP while link-layer
+tools still work. It should not ship adversarial compliance modules, product
+workarounds, private policy, or host-specific rules.
+
 ## Operator Contract
 
 The stable generic commands are:

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -195,6 +195,10 @@ def test_project_spec_is_public_and_generic():
     assert "PyPI trusted publishing is staged" in spec
     assert "Coverage gate ratcheted to 50 percent" in spec
     assert "Consumers own their own device names, secrets, and recovery policy" in spec
+    assert "Boundary Decisions" in spec
+    assert "ABR-style approval keepalives and scripted approvers are out of scope" in spec
+    assert "Sophos, ZTNA, CryptoGuard" in spec
+    assert "should not ship adversarial compliance modules" in spec
 
     forbidden = [
         "crs309-main",


### PR DESCRIPTION
## Summary
- documents ABR keepalives/scripted approvers as out of scope for DarwinNicUtil
- documents Sophos/ZTNA/CryptoGuard-specific integrations as out of scope while preserving generic host-policy diagnostics
- adds docs guard coverage for the boundary decision

## Validation
- uv run --extra dev python -m pytest tests/test_docs.py -q
- uv run --extra dev mkdocs build --strict
- uv run --extra dev python -m pytest -q