### PR TITLE
Clarify PyPI cutover runbook

### DIFF
--- a/docs/artifacts.md
+++ b/docs/artifacts.md
@@ -122,6 +122,26 @@ does not use a stored PyPI API token. Keep README and quickstart install
 commands focused on Nix, FlakeHub, wheel/source, and source checkout paths
 until a real PyPI upload is validated.
 
+PyPI cutover checklist:
+
+1. Create the PyPI pending publisher for the package above with the exact
+   owner, repository, workflow, and environment values in the table.
+2. Verify the GitHub repository environment is named `pypi`; the workflow
+   publisher identity depends on that environment string.
+3. Prepare a new release version after `v2.1.0`, such as `v2.1.1`.
+4. Do not move or reuse the existing `v2.1.0` tag for the first PyPI upload.
+   The release workflow is loaded from the tagged commit, and `v2.1.0`
+   predates the PyPI publishing job.
+5. Push the new `v*.*.*` tag and confirm the `Publish to PyPI` job succeeds.
+6. Verify the published package metadata:
+
+   ```bash
+   curl -fsS https://pypi.org/pypi/darwin-mgmt-nic-configurator/json
+   ```
+
+7. Only after that verification, add README and quickstart install commands for
+   PyPI.
+
 ## Not Yet Primary Artifacts
 
 | Surface | Current status |

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -157,6 +157,12 @@ def test_pypi_publish_surface_is_staged_but_not_overclaimed():
 
     assert "PyPI Trusted Publishing" in artifacts
     assert "darwin-mgmt-nic-configurator" in artifacts
+    assert "PyPI cutover checklist" in artifacts
+    assert "Verify the GitHub repository environment is named `pypi`" in artifacts
+    assert "Do not move or reuse the existing `v2.1.0` tag" in artifacts
+    assert "predates the PyPI publishing job" in artifacts
+    assert "curl -fsS https://pypi.org/pypi/darwin-mgmt-nic-configurator/json" in artifacts
+    assert "Only after that verification" in artifacts
     assert "release.yml" in artifacts
     assert "`pypi`" in artifacts
     assert "pypa/gh-action-pypi-publish@release/v1" in release_workflow


### PR DESCRIPTION
## Summary
- documents the PyPI cutover checklist in artifact docs
- records that the first PyPI upload needs a new post-v2.1.0 version/tag
- adds doc guards so README/quickstart stay conservative until PyPI is actually live

## Validation
- uv run --extra dev python -m pytest tests/test_docs.py -q
- uv run --extra dev mkdocs build --strict
- uv run --extra dev python -m pytest -q

## Notes
- PyPI API still returns 404 for darwin-mgmt-nic-configurator
- GitHub environment pypi now exists for the release workflow