### PR TITLE
Add package metadata links

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,11 @@ darwin-nic = "darwin_mgmt_nic.app:main"
 
 [project.urls]
 Homepage = "https://github.com/Jesssullivan/DarwinNicUtil"
+Documentation = "https://jesssullivan.github.io/DarwinNicUtil"
 Repository = "https://github.com/Jesssullivan/DarwinNicUtil.git"
+Changelog = "https://github.com/Jesssullivan/DarwinNicUtil/blob/main/CHANGELOG.md"
+Releases = "https://github.com/Jesssullivan/DarwinNicUtil/releases"
+FlakeHub = "https://flakehub.com/f/Jesssullivan/DarwinNicUtil"
 Issues = "https://github.com/Jesssullivan/DarwinNicUtil/issues"
 
 [build-system]

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -9,6 +9,10 @@ def test_project_metadata_points_at_github_repository():
     pyproject = (REPO_ROOT / "pyproject.toml").read_text()
 
     assert "https://github.com/Jesssullivan/DarwinNicUtil" in pyproject
+    assert 'Documentation = "https://jesssullivan.github.io/DarwinNicUtil"' in pyproject
+    assert 'Changelog = "https://github.com/Jesssullivan/DarwinNicUtil/blob/main/CHANGELOG.md"' in pyproject
+    assert 'Releases = "https://github.com/Jesssullivan/DarwinNicUtil/releases"' in pyproject
+    assert 'FlakeHub = "https://flakehub.com/f/Jesssullivan/DarwinNicUtil"' in pyproject
     assert "gitlab.com/tinyland/projects/darwin-mgmt-nic-configurator" not in pyproject
 
 


### PR DESCRIPTION
## Summary
- adds Documentation, Changelog, Releases, and FlakeHub project URLs to package metadata
- guards the public package URLs in docs tests
- verifies built wheel metadata exposes the expected PyPI project links

## Validation
- uv build
- uv run --with twine python -m twine check dist/*
- uv run --extra dev python -m pytest tests/test_docs.py -q
- uv run --extra dev python -m pytest -q

## Notes
- Local GPG signing timed out, so the commit was created without local GPG signing.