### PR TITLE
Prepare v2.1.1 PyPI release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to DarwinNicUtil are recorded here.
 
 ## Unreleased
 
+- No unreleased changes.
+
+## 2.1.1 - 2026-04-25
+
+- Stage the post-v2.1.0 PyPI cutover release.
+- Add PyPI project metadata links for documentation, changelog, releases, and
+  FlakeHub.
+- Document the PyPI trusted-publishing cutover checklist.
+- Keep PyPI install commands out of README and quickstart until the first
+  upload is validated.
+
+## 2.1.0 - 2026-04-25
+
 - Restrict future release workflow uploads to wheel and source distribution
   artifacts only.
 - Clarify release artifact docs so they describe only wheel and source
@@ -11,8 +24,6 @@ All notable changes to DarwinNicUtil are recorded here.
 - Track post-v2.1 distribution follow-ups for PyPI, standalone binaries,
   Homebrew, FlakeHub, and Bazel/BCR without advertising unproven install paths.
 - Mark Homebrew as deferred until a supported PyPI or standalone artifact exists.
-
-## 2.1.0 - 2026-04-25
 
 ### CI/CD
 

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -6,7 +6,7 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "darwin-nic";
-  version = "2.1.0";
+  version = "2.1.1";
   pyproject = true;
 
   src = lib.cleanSource ./..;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "darwin-mgmt-nic-configurator"
-version = "2.1.0"
+version = "2.1.1"
 description = "Darwin USB network interface configurator for management access to network devices"
 readme = "README.md"
 requires-python = ">=3.14"

--- a/src/darwin_mgmt_nic/__init__.py
+++ b/src/darwin_mgmt_nic/__init__.py
@@ -2,10 +2,10 @@
 USB Network Interface Configurator Package
 USB NIC detection and configuration with factory pattern
 
-Version 2.1.0 - Python 3.14+ with modern type system
+Version 2.1.1 - Python 3.14+ with modern type system
 """
 
-__version__ = "2.1.0"
+__version__ = "2.1.1"
 
 from .config import NetworkConfig, NetworkInterface
 from .configurator import USBNICConfigurator

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -236,7 +236,7 @@ def test_root_entrypoint_uses_package_app_version():
         check=True,
     )
 
-    assert result.stdout.strip() == "darwin-nic 2.1.0"
+    assert result.stdout.strip() == "darwin-nic 2.1.1"
 
 
 def test_binary_build_script_is_local_smoke_test_only():

--- a/uv.lock
+++ b/uv.lock
@@ -168,7 +168,7 @@ wheels = [
 
 [[package]]
 name = "darwin-mgmt-nic-configurator"
-version = "2.1.0"
+version = "2.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "rich" },


### PR DESCRIPTION
## Summary
- bumps package/Nix/runtime version surfaces to 2.1.1
- adds the v2.1.1 changelog entry for PyPI cutover prep
- updates version guard coverage and lockfile metadata

## Validation
- uv build
- uv run --with twine python -m twine check dist/*
- inspected wheel METADATA for version 2.1.1 and project URLs
- uv run --extra dev python -m pytest tests/test_docs.py -q
- uv run --extra dev python -m pytest -q
- uv run --extra dev mkdocs build --strict

## Release gating
Keep this PR draft until the PyPI pending publisher exists for `darwin-mgmt-nic-configurator` with owner `Jesssullivan`, repository `DarwinNicUtil`, workflow `release.yml`, and environment `pypi`.

After merge, tag `v2.1.1`; do not move or reuse `v2.1.0`.