### PR TITLE
Document live PyPI install

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,14 +11,18 @@ path intact.
 
 - macOS is the primary supported platform.
 - Linux support is experimental and currently limited.
-- Release artifacts are source distributions, wheels, Nix packages, and
-  FlakeHub releases.
+- Release artifacts are PyPI distributions, GitHub Release wheel/source
+  files, Nix packages, and FlakeHub releases.
 - The PyInstaller spec is retained for manual builds, but standalone binaries
   are not the primary release artifact yet.
 
 ## Quick Start
 
 ```bash
+# Install from PyPI
+uv tool install darwin-mgmt-nic-configurator
+darwin-nic status
+
 # Run the stable v2.1.0 release from FlakeHub
 nix run "https://flakehub.com/f/Jesssullivan/DarwinNicUtil/v2.1.0" -- status
 
@@ -51,6 +55,9 @@ darwin-nic configure --profile homelab --preserve-wifi
 ## Install
 
 ```bash
+# PyPI
+uv tool install darwin-mgmt-nic-configurator
+
 # Nix profile from FlakeHub
 nix profile install "https://flakehub.com/f/Jesssullivan/DarwinNicUtil/v2.1.0"
 
@@ -158,11 +165,10 @@ Run `just` with no arguments to see all recipes.
 
 Current release artifacts are:
 
-- Python wheel and source distribution from `uv build`;
+- PyPI distribution for `darwin-mgmt-nic-configurator`;
+- GitHub Release wheel and source distribution files;
 - Nix flake package outputs, including FlakeHub `v2.1.0`;
 - MkDocs site artifacts from the docs workflow.
 
-GitHub release, FlakeHub, and docs workflows are present for tag-based
-publication. The PyPI trusted-publishing workflow is staged but not documented
-as an install path until the first upload is validated. Standalone binary
-distribution remains a tracked release follow-up.
+GitHub Release, PyPI, FlakeHub, and docs workflows are present for tag-based
+publication. Standalone binary distribution remains a tracked release follow-up.

--- a/docs/artifacts.md
+++ b/docs/artifacts.md
@@ -1,7 +1,7 @@
 # Artifacts
 
 This project currently treats wheel/source distributions, Nix packages,
-FlakeHub releases, and the MkDocs site as release artifacts.
+PyPI distributions, FlakeHub releases, and the MkDocs site as release artifacts.
 
 ## Python Packages
 
@@ -102,13 +102,16 @@ Do not document standalone binaries as a public install path until CI builds
 the artifact, tests it, produces checksums, and the signing/notarization policy
 is explicit.
 
-## PyPI Trusted Publishing
+## PyPI
 
-PyPI publication is staged in the release workflow, but it is not a supported
-install path until the first trusted-publishing upload succeeds.
+PyPI publication is live for `darwin-mgmt-nic-configurator` through trusted
+publishing. Install with:
 
-The package name planned for PyPI is `darwin-mgmt-nic-configurator`. Configure
-a PyPI pending publisher before pushing the first PyPI-enabled release tag:
+```bash
+uv tool install darwin-mgmt-nic-configurator
+```
+
+The project was created through a PyPI pending publisher using these values:
 
 | Field | Value |
 |-------|-------|
@@ -118,11 +121,10 @@ a PyPI pending publisher before pushing the first PyPI-enabled release tag:
 | Environment | `pypi` |
 
 The release workflow uses GitHub OIDC with `pypa/gh-action-pypi-publish` and
-does not use a stored PyPI API token. Keep README and quickstart install
-commands focused on Nix, FlakeHub, wheel/source, and source checkout paths
-until a real PyPI upload is validated.
+does not use a stored PyPI API token. README and quickstart now include PyPI
+install commands because the `v2.1.1` upload has been validated.
 
-PyPI cutover checklist:
+The completed cutover path was:
 
 1. Create the PyPI pending publisher for the package above with the exact
    owner, repository, workflow, and environment values in the table.
@@ -139,14 +141,13 @@ PyPI cutover checklist:
    curl -fsS https://pypi.org/pypi/darwin-mgmt-nic-configurator/json
    ```
 
-7. Only after that verification, add README and quickstart install commands for
-   PyPI.
+7. README and quickstart install commands were added after verification.
 
 ## Not Yet Primary Artifacts
 
 | Surface | Current status |
 |---------|----------------|
-| PyPI | Trusted-publishing workflow is staged; install docs remain pending until first upload is validated, tracked in [GitHub #11](https://github.com/Jesssullivan/DarwinNicUtil/issues/11) |
+| PyPI | Supported through trusted publishing; latest validated upload is `2.1.1` |
 | Standalone binary | PyInstaller spec exists, but binary releases are not validated yet; tracked in [GitHub #9](https://github.com/Jesssullivan/DarwinNicUtil/issues/9) |
 | Homebrew | Deferred; there is no active DarwinNicUtil tap/formula path until PyPI or standalone artifacts are proven, with the decision recorded in [GitHub #10](https://github.com/Jesssullivan/DarwinNicUtil/issues/10) |
 | Bazel / BCR | Not a primary install path; evaluate only if a real downstream Bazel/Bzlmod consumer needs it, tracked in [GitHub #17](https://github.com/Jesssullivan/DarwinNicUtil/issues/17) |
@@ -155,8 +156,8 @@ PyPI cutover checklist:
 ## Bazel / BCR Decision
 
 DarwinNicUtil does not ship a Bazel or Bzlmod module today. The validated
-distribution paths are Python wheel/source distributions, GitHub Releases, Nix
-flake references, and FlakeHub releases.
+distribution paths are PyPI distributions, Python wheel/source distributions,
+GitHub Releases, Nix flake references, and FlakeHub releases.
 
 Do not introduce Bazel as a default local build, test, or install path for this
 repo. Current repo and sibling-repo evidence does not show a downstream
@@ -172,6 +173,6 @@ If a real downstream Bazel consumer appears, keep the surface minimal:
   FlakeHub unless the Bazel path becomes a validated public artifact.
 
 Bazel/BCR work should stay aligned with the broader Tinyland distribution
-substrate. Homebrew should be reconsidered only after a supported PyPI or
-standalone artifact exists. This repo should only document public, validated
-install paths.
+substrate. Homebrew can now be reconsidered if a tap has a real
+maintainer/consumer path, but it remains deferred until then. This repo should
+only document public, validated install paths.

--- a/docs/development.md
+++ b/docs/development.md
@@ -89,7 +89,7 @@ GitHub Actions now own the public validation path:
 | `ci.yml` | Format, lint, type-check, tests, docs build, package build |
 | `secret-detection.yml` | Gitleaks and TruffleHog scanning |
 | `docs.yml` | MkDocs build and GitHub Pages artifact upload |
-| `release.yml` | Tag-triggered wheel/source distribution, GitHub Release, and staged PyPI publish |
+| `release.yml` | Tag-triggered wheel/source distribution, GitHub Release, and PyPI publish |
 
 GitLab CI remains in the repository for compatibility, but GitHub is the
 release-facing surface.
@@ -109,12 +109,11 @@ nix flake check
 Then tag from a clean, reviewed branch:
 
 ```bash
-git tag -a v2.1.0 -m "Release v2.1.0"
-git push origin v2.1.0
+git tag -a v2.1.1 -m "Release v2.1.1"
+git push origin v2.1.1
 ```
 
 The release workflow attaches only wheel and source distribution files from
-`dist/` to the GitHub Release. It also contains the PyPI trusted-publishing job
-for tag builds; configure the PyPI pending publisher for
-`release.yml`/`pypi` before relying on it. Standalone binary distribution
-remains a follow-up release task.
+`dist/` to the GitHub Release. It also publishes to PyPI through trusted
+publishing for tag builds. Standalone binary distribution remains a follow-up
+release task.

--- a/docs/index.md
+++ b/docs/index.md
@@ -71,7 +71,6 @@ flowchart LR
 
 ## Artifacts
 
-The release path currently supports Python wheel/source distributions, Nix
-packages, FlakeHub releases, and MkDocs site artifacts. The PyPI publish job is
-staged behind trusted publishing, but PyPI install docs wait for the first
-validated upload. Standalone binary publication remains a tracked follow-up.
+The release path supports PyPI distributions, GitHub Release wheel/source
+files, Nix packages, FlakeHub releases, and MkDocs site artifacts. Standalone
+binary publication remains a tracked follow-up.

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -6,11 +6,11 @@ out-of-band management access while preserving Wi-Fi and tailnet connectivity.
 Primary docs:
 
 - `README.md`: install, usage, safety features, and development commands.
-- `docs/quickstart.md`: current Nix, source, and uv tool startup flows.
+- `docs/quickstart.md`: current PyPI, Nix, source, and uv tool startup flows.
 - `docs/cli.md`: command and option reference.
 - `docs/bastion.md`: generic bastion/OOB operator flow and boundaries.
 - `docs/artifacts.md`: current release artifact policy, including GitHub
-  Releases and FlakeHub.
+  Releases, PyPI, and FlakeHub.
 - `docs/project-spec.md`: public project spec and productionization summary.
 - `docs/architecture.md`: module structure and safety architecture.
 - `docs/superpowers/release-sprint-plan.md`: release-readiness sprint plan.

--- a/docs/project-spec.md
+++ b/docs/project-spec.md
@@ -90,15 +90,13 @@ Consumers own their own device names, secrets, and recovery policy.
 
 Current validated surfaces:
 
+- PyPI distribution for `darwin-mgmt-nic-configurator`.
 - GitHub Release with wheel and source distribution artifacts.
 - Nix flake package outputs.
 - FlakeHub release `v2.1.0` and rolling channel.
 - MkDocs site published by GitHub Pages.
 
 Staged or deferred surfaces:
-
-- PyPI trusted publishing is staged in the release workflow, pending PyPI-side
-  publisher setup and a validated first upload.
 - Standalone binaries are local smoke-test artifacts only until CI builds,
   tests, checksums, and signing/notarization policy exist.
 - Homebrew is deferred until PyPI or standalone binary artifacts are proven.
@@ -116,14 +114,13 @@ The post-v2.1 hardening pass added:
   and development.
 - Agent-facing docs in `AGENTS.md` and `docs/llms.txt`.
 - FlakeHub publication workflow and documented release reference.
-- PyPI trusted-publishing workflow staging.
+- PyPI trusted publishing and validated `2.1.1` upload.
 - Explicit artifact policy for PyPI, binaries, Homebrew, and Bazel/BCR.
 - Coverage gate ratcheted to 50 percent, with current coverage above 55
   percent.
 
 ## Next Work
 
-- Complete PyPI publication after creating the pending publisher.
 - Draft a longer external blog post only if there is a maintained public venue.
 - Add guided-setup behavior tests before the next coverage ratchet.
 - Keep Sophos and ABR ideas as separate boundary spikes until they have a

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -4,6 +4,13 @@ Get a USB management NIC configured without letting it take over normal Wi-Fi or
 
 ## Installation
 
+=== "PyPI"
+
+    ```bash
+    uv tool install darwin-mgmt-nic-configurator
+    darwin-nic setup
+    ```
+
 === "Nix"
 
     ```bash

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -144,29 +144,30 @@ def test_artifacts_docs_match_current_release_policy():
     assert "FlakeHub releases are `v2.1.0`" in artifacts
     assert "nix run github:Jesssullivan/DarwinNicUtil -- status" in artifacts
     assert "https://flakehub.com/f/Jesssullivan/DarwinNicUtil/v2.1.0" in readme
-    assert "PyPI trusted-publishing workflow is staged" in readme
-    assert "not documented" in readme
-    assert "until the first upload is validated" in readme
+    assert "PyPI distribution for `darwin-mgmt-nic-configurator`" in readme
+    assert "GitHub Release, PyPI, FlakeHub, and docs workflows" in readme
 
     if flakehub_workflow_path.exists():
         flakehub_workflow = flakehub_workflow_path.read_text()
         assert "DeterminateSystems/flakehub-push@main" in flakehub_workflow
 
 
-def test_pypi_publish_surface_is_staged_but_not_overclaimed():
+def test_pypi_publish_surface_is_live_and_documented():
     artifacts = (REPO_ROOT / "docs" / "artifacts.md").read_text()
     release_workflow = (REPO_ROOT / ".github" / "workflows" / "release.yml").read_text()
     readme = (REPO_ROOT / "README.md").read_text()
     quickstart = (REPO_ROOT / "docs" / "quickstart.md").read_text()
 
-    assert "PyPI Trusted Publishing" in artifacts
+    assert "## PyPI" in artifacts
     assert "darwin-mgmt-nic-configurator" in artifacts
-    assert "PyPI cutover checklist" in artifacts
+    assert "PyPI publication is live" in artifacts
+    assert "uv tool install darwin-mgmt-nic-configurator" in artifacts
+    assert "latest validated upload is `2.1.1`" in artifacts
+    assert "The completed cutover path was" in artifacts
     assert "Verify the GitHub repository environment is named `pypi`" in artifacts
     assert "Do not move or reuse the existing `v2.1.0` tag" in artifacts
     assert "predates the PyPI publishing job" in artifacts
     assert "curl -fsS https://pypi.org/pypi/darwin-mgmt-nic-configurator/json" in artifacts
-    assert "Only after that verification" in artifacts
     assert "release.yml" in artifacts
     assert "`pypi`" in artifacts
     assert "pypa/gh-action-pypi-publish@release/v1" in release_workflow
@@ -175,8 +176,11 @@ def test_pypi_publish_surface_is_staged_but_not_overclaimed():
     assert "name: pypi" in release_workflow
     assert "username:" not in release_workflow
     assert "password:" not in release_workflow
-    assert "pipx install darwin-mgmt-nic-configurator" not in readme
-    assert "pipx install darwin-mgmt-nic-configurator" not in quickstart
+    assert "uv tool install darwin-mgmt-nic-configurator" in readme
+    assert "uv tool install darwin-mgmt-nic-configurator" in quickstart
+    assert "PyPI trusted-publishing workflow is staged" not in readme
+    assert "until the first upload is validated" not in readme
+    assert "install docs remain pending" not in artifacts
 
 
 def test_coverage_gate_is_ratchet_to_fifty_percent():
@@ -202,7 +206,7 @@ def test_project_spec_is_public_and_generic():
     assert "Project Spec: project-spec.md" in mkdocs
     assert "docs/project-spec.md" in llms
     assert "Productionization Results" in spec
-    assert "PyPI trusted publishing is staged" in spec
+    assert "PyPI trusted publishing and validated `2.1.1` upload" in spec
     assert "Coverage gate ratcheted to 50 percent" in spec
     assert "Consumers own their own device names, secrets, and recovery policy" in spec
     assert "Boundary Decisions" in spec


### PR DESCRIPTION
## Summary
- promotes PyPI from staged to supported after the verified v2.1.1 upload
- adds `uv tool install darwin-mgmt-nic-configurator` to README and quickstart
- updates artifact, project spec, development, index, and llms docs to reflect live PyPI publishing
- updates docs tests from pending-PyPI guards to live-PyPI guards

## Validation
- curl -fsS https://pypi.org/pypi/darwin-mgmt-nic-configurator/json | jq -r .info.version -> 2.1.1
- gh run watch 24939210054 --exit-status
- uv run --extra dev python -m pytest -q
- uv run --extra dev mkdocs build --strict

Closes #11.