### PR TITLE
Polish final release surfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@ All notable changes to DarwinNicUtil are recorded here.
 
 ## Unreleased
 
-- No unreleased changes.
+- Refresh public install and artifact docs around the validated `v2.1.1` PyPI
+  and FlakeHub release surfaces.
+- Move PyPI out of the deferred artifact policy after the trusted-publishing
+  upload succeeded.
 
 ## 2.1.1 - 2026-04-25
 

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ path intact.
 uv tool install darwin-mgmt-nic-configurator
 darwin-nic status
 
-# Run the stable v2.1.0 release from FlakeHub
-nix run "https://flakehub.com/f/Jesssullivan/DarwinNicUtil/v2.1.0" -- status
+# Run the stable v2.1.1 release from FlakeHub
+nix run "https://flakehub.com/f/Jesssullivan/DarwinNicUtil/v2.1.1" -- status
 
 # Or run directly from GitHub
 nix run github:Jesssullivan/DarwinNicUtil -- status
@@ -59,7 +59,7 @@ darwin-nic configure --profile homelab --preserve-wifi
 uv tool install darwin-mgmt-nic-configurator
 
 # Nix profile from FlakeHub
-nix profile install "https://flakehub.com/f/Jesssullivan/DarwinNicUtil/v2.1.0"
+nix profile install "https://flakehub.com/f/Jesssullivan/DarwinNicUtil/v2.1.1"
 
 # Nix profile from GitHub
 nix profile install github:Jesssullivan/DarwinNicUtil
@@ -167,7 +167,7 @@ Current release artifacts are:
 
 - PyPI distribution for `darwin-mgmt-nic-configurator`;
 - GitHub Release wheel and source distribution files;
-- Nix flake package outputs, including FlakeHub `v2.1.0`;
+- Nix flake package outputs, including FlakeHub `v2.1.1`;
 - MkDocs site artifacts from the docs workflow.
 
 GitHub Release, PyPI, FlakeHub, and docs workflows are present for tag-based

--- a/docs/artifacts.md
+++ b/docs/artifacts.md
@@ -48,7 +48,7 @@ Downstream Home Manager users should consume the flake input and install
 The stable FlakeHub release reference is:
 
 ```bash
-nix run "https://flakehub.com/f/Jesssullivan/DarwinNicUtil/v2.1.0" -- status
+nix run "https://flakehub.com/f/Jesssullivan/DarwinNicUtil/v2.1.1" -- status
 ```
 
 The direct GitHub flake reference remains supported:
@@ -60,7 +60,7 @@ nix run github:Jesssullivan/DarwinNicUtil -- status
 FlakeHub publication runs through the `Publish to FlakeHub` GitHub Actions
 workflow. Tagged releases publish from `v*.*.*` tags, and maintainers can run a
 manual rolling validation from the workflow dispatch form. The current public
-FlakeHub releases are `v2.1.0` and the rolling `*` channel.
+FlakeHub releases are `v2.1.1` and the rolling `*` channel.
 
 ## Documentation Site
 
@@ -105,7 +105,7 @@ is explicit.
 ## PyPI
 
 PyPI publication is live for `darwin-mgmt-nic-configurator` through trusted
-publishing. Install with:
+publishing. The latest validated upload is `2.1.1`. Install with:
 
 ```bash
 uv tool install darwin-mgmt-nic-configurator
@@ -130,7 +130,8 @@ The completed cutover path was:
    owner, repository, workflow, and environment values in the table.
 2. Verify the GitHub repository environment is named `pypi`; the workflow
    publisher identity depends on that environment string.
-3. Prepare a new release version after `v2.1.0`, such as `v2.1.1`.
+3. Prepare a new release version after the last non-PyPI tag; `v2.1.1` was
+   used for the first upload after `v2.1.0`.
 4. Do not move or reuse the existing `v2.1.0` tag for the first PyPI upload.
    The release workflow is loaded from the tagged commit, and `v2.1.0`
    predates the PyPI publishing job.
@@ -143,13 +144,12 @@ The completed cutover path was:
 
 7. README and quickstart install commands were added after verification.
 
-## Not Yet Primary Artifacts
+## Deferred and Non-Primary Surfaces
 
 | Surface | Current status |
 |---------|----------------|
-| PyPI | Supported through trusted publishing; latest validated upload is `2.1.1` |
 | Standalone binary | PyInstaller spec exists, but binary releases are not validated yet; tracked in [GitHub #9](https://github.com/Jesssullivan/DarwinNicUtil/issues/9) |
-| Homebrew | Deferred; there is no active DarwinNicUtil tap/formula path until PyPI or standalone artifacts are proven, with the decision recorded in [GitHub #10](https://github.com/Jesssullivan/DarwinNicUtil/issues/10) |
+| Homebrew | Deferred; there is no active DarwinNicUtil tap/formula path, with the decision recorded in [GitHub #10](https://github.com/Jesssullivan/DarwinNicUtil/issues/10) |
 | Bazel / BCR | Not a primary install path; evaluate only if a real downstream Bazel/Bzlmod consumer needs it, tracked in [GitHub #17](https://github.com/Jesssullivan/DarwinNicUtil/issues/17) |
 | Container image | Not applicable for the CLI today |
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,7 +22,7 @@ For the public release shape and productionization summary, see the
 
 ```bash
 # Stable release from FlakeHub
-nix run "https://flakehub.com/f/Jesssullivan/DarwinNicUtil/v2.1.0" -- status
+nix run "https://flakehub.com/f/Jesssullivan/DarwinNicUtil/v2.1.1" -- status
 
 # Direct GitHub flake reference
 nix run github:Jesssullivan/DarwinNicUtil -- status

--- a/docs/project-spec.md
+++ b/docs/project-spec.md
@@ -93,13 +93,13 @@ Current validated surfaces:
 - PyPI distribution for `darwin-mgmt-nic-configurator`.
 - GitHub Release with wheel and source distribution artifacts.
 - Nix flake package outputs.
-- FlakeHub release `v2.1.0` and rolling channel.
+- FlakeHub release `v2.1.1` and rolling channel.
 - MkDocs site published by GitHub Pages.
 
 Staged or deferred surfaces:
 - Standalone binaries are local smoke-test artifacts only until CI builds,
   tests, checksums, and signing/notarization policy exist.
-- Homebrew is deferred until PyPI or standalone binary artifacts are proven.
+- Homebrew remains deferred until there is an active tap maintainer/consumer path.
 - Bazel/Bzlmod is not a primary install path unless a real downstream consumer
   appears.
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -15,7 +15,7 @@ Get a USB management NIC configured without letting it take over normal Wi-Fi or
 
     ```bash
     # Stable release
-    nix run "https://flakehub.com/f/Jesssullivan/DarwinNicUtil/v2.1.0" -- setup
+    nix run "https://flakehub.com/f/Jesssullivan/DarwinNicUtil/v2.1.1" -- setup
 
     # Direct GitHub flake reference
     nix run github:Jesssullivan/DarwinNicUtil -- configure \

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -132,6 +132,9 @@ def test_artifacts_docs_match_current_release_policy():
     assert "Standalone binaries are not supported release artifacts yet" in artifacts
     assert "just build-binary" in artifacts
     assert "signing/notarization policy" in artifacts
+    assert "Deferred and Non-Primary Surfaces" in artifacts
+    assert "Not Yet Primary Artifacts" not in artifacts
+    assert "| PyPI |" not in artifacts
     assert "Homebrew | Deferred" in artifacts
     assert "no active DarwinNicUtil tap/formula path" in artifacts
     assert "DarwinNicUtil does not ship a Bazel or Bzlmod module today" in artifacts
@@ -139,11 +142,11 @@ def test_artifacts_docs_match_current_release_policy():
     assert "`MODULE.bazel` or `BUILD.bazel` consumer" in artifacts
     assert "Do not introduce Bazel as a default local build" in artifacts
     assert "FlakeHub releases" in artifacts
-    assert "https://flakehub.com/f/Jesssullivan/DarwinNicUtil/v2.1.0" in artifacts
+    assert "https://flakehub.com/f/Jesssullivan/DarwinNicUtil/v2.1.1" in artifacts
     assert "current public" in artifacts
-    assert "FlakeHub releases are `v2.1.0`" in artifacts
+    assert "FlakeHub releases are `v2.1.1`" in artifacts
     assert "nix run github:Jesssullivan/DarwinNicUtil -- status" in artifacts
-    assert "https://flakehub.com/f/Jesssullivan/DarwinNicUtil/v2.1.0" in readme
+    assert "https://flakehub.com/f/Jesssullivan/DarwinNicUtil/v2.1.1" in readme
     assert "PyPI distribution for `darwin-mgmt-nic-configurator`" in readme
     assert "GitHub Release, PyPI, FlakeHub, and docs workflows" in readme
 


### PR DESCRIPTION
## Summary

- Update public install docs to use the validated v2.1.1 FlakeHub release.
- Move PyPI out of the deferred artifact table now that trusted publishing has completed.
- Clarify Homebrew remains deferred until there is an active tap maintainer or consumer path.

## Validation

- `uv run --extra dev python -m pytest tests/test_docs.py -q`
- `uv run --extra dev mkdocs build --strict`
- `uv run --extra dev python -m pytest -q`
- `just check`
