### PR TITLE
Improve docs install and Pages surfaces

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -44,6 +44,8 @@ jobs:
 
       - name: Configure Pages
         uses: actions/configure-pages@v6
+        with:
+          enablement: true
 
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to DarwinNicUtil are recorded here.
 
 ## Unreleased
 
+- Fix the MkDocs deployment workflow so GitHub Pages can be enabled and
+  deployed from Actions.
+- Point docs metadata at the canonical public docs URL.
+- Tighten README and MkDocs install/download tables for PyPI, FlakeHub,
+  GitHub Releases, source checkout, and integration surfaces.
 - Refresh public install and artifact docs around the validated `v2.1.1` PyPI
   and FlakeHub release surfaces.
 - Move PyPI out of the deferred artifact policy after the trusted-publishing

--- a/README.md
+++ b/README.md
@@ -15,58 +15,43 @@ path intact.
   files, Nix packages, and FlakeHub releases.
 - The PyInstaller spec is retained for manual builds, but standalone binaries
   are not the primary release artifact yet.
+- Public docs are built with MkDocs and published at
+  <https://transscendsurvival.org/DarwinNicUtil/>.
 
 ## Quick Start
 
 ```bash
-# Install from PyPI
+# Recommended CLI install
 uv tool install darwin-mgmt-nic-configurator
 darwin-nic status
+darwin-nic init-config
+darwin-nic configure --profile homelab --preserve-wifi
 
-# Run the stable v2.1.1 release from FlakeHub
+# Run without installing, using the stable FlakeHub release
 nix run "https://flakehub.com/f/Jesssullivan/DarwinNicUtil/v2.1.1" -- status
-
-# Or run directly from GitHub
-nix run github:Jesssullivan/DarwinNicUtil -- status
-nix run github:Jesssullivan/DarwinNicUtil -- configure \
-  --device-ip <device-ipv4> \
-  --laptop-ip <usb-nic-ipv4> \
-  --mgmt-network <cidr> \
-  --preserve-wifi
-
-# Run from a source checkout
-uv sync --extra dev
-uv run darwin-nic status
-uv run darwin-nic configure \
-  --device-ip <device-ipv4> \
-  --laptop-ip <usb-nic-ipv4> \
-  --mgmt-network <cidr> \
-  --preserve-wifi
 ```
 
-For repeated use, create a profile:
+For a one-off setup without a saved profile:
 
 ```bash
-darwin-nic init-config
-darwin-nic config
-darwin-nic configure --profile homelab --preserve-wifi
+darwin-nic configure \
+  --device-ip <device-ipv4> \
+  --laptop-ip <usb-nic-ipv4> \
+  --mgmt-network <cidr> \
+  --preserve-wifi
 ```
 
 ## Install
 
-```bash
-# PyPI
-uv tool install darwin-mgmt-nic-configurator
+| Path | Use When | Command |
+|------|----------|---------|
+| PyPI | You want the normal CLI on your PATH | `uv tool install darwin-mgmt-nic-configurator` |
+| FlakeHub | You want a stable Nix release | `nix profile install "https://flakehub.com/f/Jesssullivan/DarwinNicUtil/v2.1.1"` |
+| GitHub flake | You want the current repository flake | `nix profile install github:Jesssullivan/DarwinNicUtil` |
+| Source checkout | You are developing or testing local changes | `uv sync --extra dev && uv run darwin-nic status` |
 
-# Nix profile from FlakeHub
-nix profile install "https://flakehub.com/f/Jesssullivan/DarwinNicUtil/v2.1.1"
-
-# Nix profile from GitHub
-nix profile install github:Jesssullivan/DarwinNicUtil
-
-# uv from source
-uv tool install .
-```
+Wheel and source distribution files are attached to GitHub Releases and
+published to PyPI. Standalone binary downloads are not supported yet.
 
 Home Manager and System Manager modules are available under `nix/modules/`.
 For the release shape and productionization summary, see
@@ -172,3 +157,10 @@ Current release artifacts are:
 
 GitHub Release, PyPI, FlakeHub, and docs workflows are present for tag-based
 publication. Standalone binary distribution remains a tracked release follow-up.
+
+Public artifact URLs:
+
+- Docs: <https://transscendsurvival.org/DarwinNicUtil/>
+- PyPI: <https://pypi.org/project/darwin-mgmt-nic-configurator/>
+- Releases: <https://github.com/Jesssullivan/DarwinNicUtil/releases>
+- FlakeHub: <https://flakehub.com/f/Jesssullivan/DarwinNicUtil>

--- a/docs/artifacts.md
+++ b/docs/artifacts.md
@@ -71,13 +71,26 @@ uv run --extra dev mkdocs build --strict
 ```
 
 The GitHub Pages workflow builds the same MkDocs site and publishes it as a
-Pages artifact.
+Pages artifact. The public docs URL is:
+
+```text
+https://transscendsurvival.org/DarwinNicUtil/
+```
+
+The docs workflow enables GitHub Pages for the repository when needed, then
+publishes the built `site/` artifact.
 
 ## GitHub Release
 
 The release workflow runs on tags matching `v*.*.*`. It builds the Python
 distribution files and attaches only the wheel and source distribution to the
 GitHub Release.
+
+Public release files are available at:
+
+```text
+https://github.com/Jesssullivan/DarwinNicUtil/releases
+```
 
 ## Standalone Binary Policy
 
@@ -109,6 +122,12 @@ publishing. The latest validated upload is `2.1.1`. Install with:
 
 ```bash
 uv tool install darwin-mgmt-nic-configurator
+```
+
+Project page:
+
+```text
+https://pypi.org/project/darwin-mgmt-nic-configurator/
 ```
 
 The project was created through a PyPI pending publisher using these values:

--- a/docs/development.md
+++ b/docs/development.md
@@ -88,7 +88,7 @@ GitHub Actions now own the public validation path:
 |----------|---------|
 | `ci.yml` | Format, lint, type-check, tests, docs build, package build |
 | `secret-detection.yml` | Gitleaks and TruffleHog scanning |
-| `docs.yml` | MkDocs build and GitHub Pages artifact upload |
+| `docs.yml` | MkDocs build and GitHub Pages deployment |
 | `release.yml` | Tag-triggered wheel/source distribution, GitHub Release, and PyPI publish |
 
 GitLab CI remains in the repository for compatibility, but GitHub is the
@@ -109,8 +109,8 @@ nix flake check
 Then tag from a clean, reviewed branch:
 
 ```bash
-git tag -a v2.1.1 -m "Release v2.1.1"
-git push origin v2.1.1
+git tag -a vX.Y.Z -m "Release vX.Y.Z"
+git push origin vX.Y.Z
 ```
 
 The release workflow attaches only wheel and source distribution files from

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,20 +18,32 @@ belong in downstream operator repositories.
 For the public release shape and productionization summary, see the
 [project spec](project-spec.md).
 
+Public artifact URLs:
+
+- Docs: <https://transscendsurvival.org/DarwinNicUtil/>
+- PyPI: <https://pypi.org/project/darwin-mgmt-nic-configurator/>
+- GitHub Releases: <https://github.com/Jesssullivan/DarwinNicUtil/releases>
+- FlakeHub: <https://flakehub.com/f/Jesssullivan/DarwinNicUtil>
+
 ## Quick Start
 
 ```bash
+# Recommended CLI install
+uv tool install darwin-mgmt-nic-configurator
+darwin-nic status
+
 # Stable release from FlakeHub
 nix run "https://flakehub.com/f/Jesssullivan/DarwinNicUtil/v2.1.1" -- status
-
-# Direct GitHub flake reference
-nix run github:Jesssullivan/DarwinNicUtil -- status
-nix run github:Jesssullivan/DarwinNicUtil -- configure \
-  --device-ip 192.168.88.1 \
-  --laptop-ip 192.168.88.100 \
-  --mgmt-network 192.168.88.0/24 \
-  --preserve-wifi
 ```
+
+## Install Path Matrix
+
+| Path | Best For | Command |
+|------|----------|---------|
+| PyPI | Normal CLI install | `uv tool install darwin-mgmt-nic-configurator` |
+| FlakeHub | Stable Nix install or one-shot run | `nix run "https://flakehub.com/f/Jesssullivan/DarwinNicUtil/v2.1.1" -- status` |
+| GitHub flake | Current repository state | `nix run github:Jesssullivan/DarwinNicUtil -- status` |
+| Source checkout | Development and local validation | `uv sync --extra dev && uv run darwin-nic status` |
 
 From a checkout:
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -3,6 +3,8 @@
 DarwinNicUtil is a Python CLI for configuring USB network interfaces for
 out-of-band management access while preserving Wi-Fi and tailnet connectivity.
 
+Public docs: https://transscendsurvival.org/DarwinNicUtil/
+
 Primary docs:
 
 - `README.md`: install, usage, safety features, and development commands.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -4,6 +4,9 @@ Get a USB management NIC configured without letting it take over normal Wi-Fi or
 
 ## Installation
 
+Use PyPI for the normal CLI, FlakeHub for stable Nix use, and source checkout
+only when developing or validating local changes.
+
 === "PyPI"
 
     ```bash
@@ -33,16 +36,6 @@ Get a USB management NIC configured without letting it take over normal Wi-Fi or
 
     uv sync --extra dev
     uv run darwin-nic setup
-    ```
-
-=== "uv Tool"
-
-    ```bash
-    git clone https://github.com/Jesssullivan/DarwinNicUtil.git
-    cd DarwinNicUtil
-
-    uv tool install .
-    darwin-nic setup
     ```
 
 ## Interactive Setup
@@ -147,6 +140,16 @@ darwin-nic dashboard
 If `status` shows the USB interface missing from `scutil --nwi` while the
 Tailscale system extension is active, ordinary sockets may be blocked by macOS
 NECP even though link-layer tools and ARP still work.
+
+## Integration Surfaces
+
+| Surface | Use |
+|---------|-----|
+| `~/.config/darwin-nic/config.toml` | User profile and defaults file |
+| `nix/modules/home-manager.nix` | Home Manager module for profile-driven installs |
+| `nix/modules/system-manager.nix` | Linux System Manager module |
+| `docs/llms.txt` | Compact agent-facing repo summary |
+| `AGENTS.md` | Repo boundaries and validation rules |
 
 ## Troubleshooting
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: Darwin Management NIC Configurator
 site_description: USB network interface configurator with WiFi preservation
-site_url: https://jesssullivan.github.io/DarwinNicUtil
+site_url: https://transscendsurvival.org/DarwinNicUtil/
 repo_url: https://github.com/Jesssullivan/DarwinNicUtil
 repo_name: Jesssullivan/DarwinNicUtil
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ darwin-nic = "darwin_mgmt_nic.app:main"
 
 [project.urls]
 Homepage = "https://github.com/Jesssullivan/DarwinNicUtil"
-Documentation = "https://jesssullivan.github.io/DarwinNicUtil"
+Documentation = "https://transscendsurvival.org/DarwinNicUtil/"
 Repository = "https://github.com/Jesssullivan/DarwinNicUtil.git"
 Changelog = "https://github.com/Jesssullivan/DarwinNicUtil/blob/main/CHANGELOG.md"
 Releases = "https://github.com/Jesssullivan/DarwinNicUtil/releases"

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -9,7 +9,7 @@ def test_project_metadata_points_at_github_repository():
     pyproject = (REPO_ROOT / "pyproject.toml").read_text()
 
     assert "https://github.com/Jesssullivan/DarwinNicUtil" in pyproject
-    assert 'Documentation = "https://jesssullivan.github.io/DarwinNicUtil"' in pyproject
+    assert 'Documentation = "https://transscendsurvival.org/DarwinNicUtil/"' in pyproject
     assert 'Changelog = "https://github.com/Jesssullivan/DarwinNicUtil/blob/main/CHANGELOG.md"' in pyproject
     assert 'Releases = "https://github.com/Jesssullivan/DarwinNicUtil/releases"' in pyproject
     assert 'FlakeHub = "https://flakehub.com/f/Jesssullivan/DarwinNicUtil"' in pyproject
@@ -70,6 +70,7 @@ def test_agent_surface_documents_no_repo_local_mcp_config():
     assert "does not ship a `.mcp.json` today" in agents
     assert "There is no repo-local `.mcp.json` at this time" in llms
     assert "sibling-repo control-plane details" in agents
+    assert "https://transscendsurvival.org/DarwinNicUtil/" in llms
 
 
 def test_bastion_docs_keep_device_specific_policy_out_of_darwin_tool():
@@ -124,6 +125,8 @@ def test_artifacts_docs_match_current_release_policy():
     artifacts = (REPO_ROOT / "docs" / "artifacts.md").read_text()
     readme = (REPO_ROOT / "README.md").read_text()
     flakehub_workflow_path = REPO_ROOT / ".github" / "workflows" / "flakehub-publish.yml"
+    docs_workflow = (REPO_ROOT / ".github" / "workflows" / "docs.yml").read_text()
+    mkdocs = (REPO_ROOT / "mkdocs.yml").read_text()
 
     assert "wheel/source distributions" in artifacts
     assert "Nix packages" in artifacts
@@ -149,6 +152,10 @@ def test_artifacts_docs_match_current_release_policy():
     assert "https://flakehub.com/f/Jesssullivan/DarwinNicUtil/v2.1.1" in readme
     assert "PyPI distribution for `darwin-mgmt-nic-configurator`" in readme
     assert "GitHub Release, PyPI, FlakeHub, and docs workflows" in readme
+    assert "https://transscendsurvival.org/DarwinNicUtil/" in artifacts
+    assert "https://transscendsurvival.org/DarwinNicUtil/" in readme
+    assert "site_url: https://transscendsurvival.org/DarwinNicUtil/" in mkdocs
+    assert "enablement: true" in docs_workflow
 
     if flakehub_workflow_path.exists():
         flakehub_workflow = flakehub_workflow_path.read_text()
@@ -181,6 +188,8 @@ def test_pypi_publish_surface_is_live_and_documented():
     assert "password:" not in release_workflow
     assert "uv tool install darwin-mgmt-nic-configurator" in readme
     assert "uv tool install darwin-mgmt-nic-configurator" in quickstart
+    assert "https://pypi.org/project/darwin-mgmt-nic-configurator/" in artifacts
+    assert "https://pypi.org/project/darwin-mgmt-nic-configurator/" in readme
     assert "PyPI trusted-publishing workflow is staged" not in readme
     assert "until the first upload is validated" not in readme
     assert "install docs remain pending" not in artifacts


### PR DESCRIPTION
## Summary

- Fix the docs deployment workflow so GitHub Pages can be enabled and deployed from Actions.
- Point MkDocs and package metadata at the canonical public docs URL.
- Tighten README and MkDocs install/download paths for PyPI, FlakeHub, GitHub Releases, source checkout, and integration surfaces.

## Live-state notes

- `https://jesssullivan.github.io/DarwinNicUtil/` currently redirects to `https://transscendsurvival.org/DarwinNicUtil/`.
- The project Pages API currently returns 404 because Pages is not enabled for this repo yet; `actions/configure-pages` was failing with `enablement: false`.
- This PR sets `enablement: true` so the next main docs run can enable and deploy Pages.

## Validation

- `uv run --extra dev python -m pytest tests/test_docs.py -q`
- `uv run --extra dev mkdocs build --strict`
- `uv run --extra dev python -m pytest -q`
- `just check`
