### PR TITLE
Prepare v2.1.2 metadata release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,16 @@ All notable changes to DarwinNicUtil are recorded here.
 
 ## Unreleased
 
+- No unreleased changes.
+
+## 2.1.2 - 2026-04-25
+
 - Fix the MkDocs deployment workflow so GitHub Pages can be enabled and
   deployed from Actions.
 - Point docs metadata at the canonical public docs URL.
 - Tighten README and MkDocs install/download tables for PyPI, FlakeHub,
   GitHub Releases, source checkout, and integration surfaces.
-- Refresh public install and artifact docs around the validated `v2.1.1` PyPI
+- Refresh public install and artifact docs around the validated `v2.1.2` PyPI
   and FlakeHub release surfaces.
 - Move PyPI out of the deferred artifact policy after the trusted-publishing
   upload succeeded.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ darwin-nic init-config
 darwin-nic configure --profile homelab --preserve-wifi
 
 # Run without installing, using the stable FlakeHub release
-nix run "https://flakehub.com/f/Jesssullivan/DarwinNicUtil/v2.1.1" -- status
+nix run "https://flakehub.com/f/Jesssullivan/DarwinNicUtil/v2.1.2" -- status
 ```
 
 For a one-off setup without a saved profile:
@@ -46,7 +46,7 @@ darwin-nic configure \
 | Path | Use When | Command |
 |------|----------|---------|
 | PyPI | You want the normal CLI on your PATH | `uv tool install darwin-mgmt-nic-configurator` |
-| FlakeHub | You want a stable Nix release | `nix profile install "https://flakehub.com/f/Jesssullivan/DarwinNicUtil/v2.1.1"` |
+| FlakeHub | You want a stable Nix release | `nix profile install "https://flakehub.com/f/Jesssullivan/DarwinNicUtil/v2.1.2"` |
 | GitHub flake | You want the current repository flake | `nix profile install github:Jesssullivan/DarwinNicUtil` |
 | Source checkout | You are developing or testing local changes | `uv sync --extra dev && uv run darwin-nic status` |
 
@@ -152,7 +152,7 @@ Current release artifacts are:
 
 - PyPI distribution for `darwin-mgmt-nic-configurator`;
 - GitHub Release wheel and source distribution files;
-- Nix flake package outputs, including FlakeHub `v2.1.1`;
+- Nix flake package outputs, including FlakeHub `v2.1.2`;
 - MkDocs site artifacts from the docs workflow.
 
 GitHub Release, PyPI, FlakeHub, and docs workflows are present for tag-based

--- a/docs/artifacts.md
+++ b/docs/artifacts.md
@@ -48,7 +48,7 @@ Downstream Home Manager users should consume the flake input and install
 The stable FlakeHub release reference is:
 
 ```bash
-nix run "https://flakehub.com/f/Jesssullivan/DarwinNicUtil/v2.1.1" -- status
+nix run "https://flakehub.com/f/Jesssullivan/DarwinNicUtil/v2.1.2" -- status
 ```
 
 The direct GitHub flake reference remains supported:
@@ -60,7 +60,7 @@ nix run github:Jesssullivan/DarwinNicUtil -- status
 FlakeHub publication runs through the `Publish to FlakeHub` GitHub Actions
 workflow. Tagged releases publish from `v*.*.*` tags, and maintainers can run a
 manual rolling validation from the workflow dispatch form. The current public
-FlakeHub releases are `v2.1.1` and the rolling `*` channel.
+FlakeHub releases are `v2.1.2` and the rolling `*` channel.
 
 ## Documentation Site
 
@@ -118,7 +118,7 @@ is explicit.
 ## PyPI
 
 PyPI publication is live for `darwin-mgmt-nic-configurator` through trusted
-publishing. The latest validated upload is `2.1.1`. Install with:
+publishing. The latest validated upload is `2.1.2`. Install with:
 
 ```bash
 uv tool install darwin-mgmt-nic-configurator
@@ -141,7 +141,7 @@ The project was created through a PyPI pending publisher using these values:
 
 The release workflow uses GitHub OIDC with `pypa/gh-action-pypi-publish` and
 does not use a stored PyPI API token. README and quickstart now include PyPI
-install commands because the `v2.1.1` upload has been validated.
+install commands because the `v2.1.2` upload has been validated.
 
 The completed cutover path was:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -33,7 +33,7 @@ uv tool install darwin-mgmt-nic-configurator
 darwin-nic status
 
 # Stable release from FlakeHub
-nix run "https://flakehub.com/f/Jesssullivan/DarwinNicUtil/v2.1.1" -- status
+nix run "https://flakehub.com/f/Jesssullivan/DarwinNicUtil/v2.1.2" -- status
 ```
 
 ## Install Path Matrix
@@ -41,7 +41,7 @@ nix run "https://flakehub.com/f/Jesssullivan/DarwinNicUtil/v2.1.1" -- status
 | Path | Best For | Command |
 |------|----------|---------|
 | PyPI | Normal CLI install | `uv tool install darwin-mgmt-nic-configurator` |
-| FlakeHub | Stable Nix install or one-shot run | `nix run "https://flakehub.com/f/Jesssullivan/DarwinNicUtil/v2.1.1" -- status` |
+| FlakeHub | Stable Nix install or one-shot run | `nix run "https://flakehub.com/f/Jesssullivan/DarwinNicUtil/v2.1.2" -- status` |
 | GitHub flake | Current repository state | `nix run github:Jesssullivan/DarwinNicUtil -- status` |
 | Source checkout | Development and local validation | `uv sync --extra dev && uv run darwin-nic status` |
 

--- a/docs/project-spec.md
+++ b/docs/project-spec.md
@@ -93,7 +93,7 @@ Current validated surfaces:
 - PyPI distribution for `darwin-mgmt-nic-configurator`.
 - GitHub Release with wheel and source distribution artifacts.
 - Nix flake package outputs.
-- FlakeHub release `v2.1.1` and rolling channel.
+- FlakeHub release `v2.1.2` and rolling channel.
 - MkDocs site published by GitHub Pages.
 
 Staged or deferred surfaces:
@@ -114,7 +114,7 @@ The post-v2.1 hardening pass added:
   and development.
 - Agent-facing docs in `AGENTS.md` and `docs/llms.txt`.
 - FlakeHub publication workflow and documented release reference.
-- PyPI trusted publishing and validated `2.1.1` upload.
+- PyPI trusted publishing and validated `2.1.2` upload.
 - Explicit artifact policy for PyPI, binaries, Homebrew, and Bazel/BCR.
 - Coverage gate ratcheted to 50 percent, with current coverage above 55
   percent.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -18,7 +18,7 @@ only when developing or validating local changes.
 
     ```bash
     # Stable release
-    nix run "https://flakehub.com/f/Jesssullivan/DarwinNicUtil/v2.1.1" -- setup
+    nix run "https://flakehub.com/f/Jesssullivan/DarwinNicUtil/v2.1.2" -- setup
 
     # Direct GitHub flake reference
     nix run github:Jesssullivan/DarwinNicUtil -- configure \

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -6,7 +6,7 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "darwin-nic";
-  version = "2.1.1";
+  version = "2.1.2";
   pyproject = true;
 
   src = lib.cleanSource ./..;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "darwin-mgmt-nic-configurator"
-version = "2.1.1"
+version = "2.1.2"
 description = "Darwin USB network interface configurator for management access to network devices"
 readme = "README.md"
 requires-python = ">=3.14"

--- a/src/darwin_mgmt_nic/__init__.py
+++ b/src/darwin_mgmt_nic/__init__.py
@@ -2,10 +2,10 @@
 USB Network Interface Configurator Package
 USB NIC detection and configuration with factory pattern
 
-Version 2.1.1 - Python 3.14+ with modern type system
+Version 2.1.2 - Python 3.14+ with modern type system
 """
 
-__version__ = "2.1.1"
+__version__ = "2.1.2"
 
 from .config import NetworkConfig, NetworkInterface
 from .configurator import USBNICConfigurator

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -145,11 +145,11 @@ def test_artifacts_docs_match_current_release_policy():
     assert "`MODULE.bazel` or `BUILD.bazel` consumer" in artifacts
     assert "Do not introduce Bazel as a default local build" in artifacts
     assert "FlakeHub releases" in artifacts
-    assert "https://flakehub.com/f/Jesssullivan/DarwinNicUtil/v2.1.1" in artifacts
+    assert "https://flakehub.com/f/Jesssullivan/DarwinNicUtil/v2.1.2" in artifacts
     assert "current public" in artifacts
-    assert "FlakeHub releases are `v2.1.1`" in artifacts
+    assert "FlakeHub releases are `v2.1.2`" in artifacts
     assert "nix run github:Jesssullivan/DarwinNicUtil -- status" in artifacts
-    assert "https://flakehub.com/f/Jesssullivan/DarwinNicUtil/v2.1.1" in readme
+    assert "https://flakehub.com/f/Jesssullivan/DarwinNicUtil/v2.1.2" in readme
     assert "PyPI distribution for `darwin-mgmt-nic-configurator`" in readme
     assert "GitHub Release, PyPI, FlakeHub, and docs workflows" in readme
     assert "https://transscendsurvival.org/DarwinNicUtil/" in artifacts
@@ -172,7 +172,7 @@ def test_pypi_publish_surface_is_live_and_documented():
     assert "darwin-mgmt-nic-configurator" in artifacts
     assert "PyPI publication is live" in artifacts
     assert "uv tool install darwin-mgmt-nic-configurator" in artifacts
-    assert "latest validated upload is `2.1.1`" in artifacts
+    assert "latest validated upload is `2.1.2`" in artifacts
     assert "The completed cutover path was" in artifacts
     assert "Verify the GitHub repository environment is named `pypi`" in artifacts
     assert "Do not move or reuse the existing `v2.1.0` tag" in artifacts
@@ -218,7 +218,7 @@ def test_project_spec_is_public_and_generic():
     assert "Project Spec: project-spec.md" in mkdocs
     assert "docs/project-spec.md" in llms
     assert "Productionization Results" in spec
-    assert "PyPI trusted publishing and validated `2.1.1` upload" in spec
+    assert "PyPI trusted publishing and validated `2.1.2` upload" in spec
     assert "Coverage gate ratcheted to 50 percent" in spec
     assert "Consumers own their own device names, secrets, and recovery policy" in spec
     assert "Boundary Decisions" in spec
@@ -252,7 +252,7 @@ def test_root_entrypoint_uses_package_app_version():
         check=True,
     )
 
-    assert result.stdout.strip() == "darwin-nic 2.1.1"
+    assert result.stdout.strip() == "darwin-nic 2.1.2"
 
 
 def test_binary_build_script_is_local_smoke_test_only():

--- a/uv.lock
+++ b/uv.lock
@@ -168,7 +168,7 @@ wheels = [
 
 [[package]]
 name = "darwin-mgmt-nic-configurator"
-version = "2.1.1"
+version = "2.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "rich" },


### PR DESCRIPTION
## Summary

- Prepare v2.1.2 so PyPI package metadata can publish the canonical docs URL.
- Bump Python package, Nix package, lockfile, CLI version, changelog, and release docs from 2.1.1 to 2.1.2.
- Keep the historical first-PyPI-upload note anchored to v2.1.1 after v2.1.0.

## Validation

- `uv run --extra dev python -m pytest tests/test_docs.py -q`
- `uv run --extra dev mkdocs build --strict`
- `uv build`
- wheel smoke test: install `dist/darwin_mgmt_nic_configurator-2.1.2-py3-none-any.whl`, run `darwin-nic --version`, run `darwin-nic --help`
- `uv run --extra dev python -m pytest -q`
- `just check`
- `nix flake check --print-build-logs`

## Release follow-up after merge

- Tag `v2.1.2` from main.
- Confirm GitHub Release, PyPI, FlakeHub, and docs workflows complete.
- Verify PyPI reports Documentation = `https://transscendsurvival.org/DarwinNicUtil/`.
